### PR TITLE
Return result from awaited hamcrest condition

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/core/AbstractHamcrestCondition.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/AbstractHamcrestCondition.java
@@ -19,7 +19,7 @@ import org.hamcrest.Matcher;
 
 import java.util.concurrent.Callable;
 
-abstract class AbstractHamcrestCondition<T> implements Condition {
+abstract class AbstractHamcrestCondition<T> implements Condition<T> {
 
 	private ConditionAwaiter conditionAwaiter;
 
@@ -46,8 +46,9 @@ abstract class AbstractHamcrestCondition<T> implements Condition {
 		};
 	}
 
-	public void await() {
+	public T await() {
 		conditionAwaiter.await();
+		return lastResult;
 	}
 
 	abstract String getCallableDescription(final Callable<T> supplier);

--- a/awaitility/src/main/java/com/jayway/awaitility/core/CallableCondition.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/CallableCondition.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Callable;
 
 import static com.jayway.awaitility.spi.Timeout.timeout_message;
 
-class CallableCondition implements Condition {
+class CallableCondition implements Condition<Void> {
 
     private final ConditionAwaiter conditionAwaiter;
 
@@ -50,7 +50,8 @@ class CallableCondition implements Condition {
 		};
 	}
 
-	public void await() {
+	public Void await() {
 		conditionAwaiter.await();
+		return null;
 	}
 }

--- a/awaitility/src/main/java/com/jayway/awaitility/core/Condition.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/Condition.java
@@ -15,7 +15,7 @@
  */
 package com.jayway.awaitility.core;
 
-interface Condition {
+interface Condition<T> {
 
-	void await();
+	T await();
 }

--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
@@ -360,12 +360,12 @@ public class ConditionFactory {
      * @throws Exception
      *             the exception
      */
-    public <T> void untilCall(T ignore, final Matcher<? super T> matcher) {
+    public <T> T untilCall(T ignore, final Matcher<? super T> matcher) {
         final MethodCaller<T> supplier = new MethodCaller<T>(MethodCallRecorder.getLastTarget(), MethodCallRecorder
                 .getLastMethod(), MethodCallRecorder.getLastArgs());
         MethodCallRecorder.reset();
         final ProxyHamcrestCondition<T> proxyCondition = new ProxyHamcrestCondition<T>(supplier, matcher, generateConditionSettings());
-        until(proxyCondition);
+        return until(proxyCondition);
     }
 
     /**
@@ -408,8 +408,8 @@ public class ConditionFactory {
      * @throws Exception
      *             the exception
      */
-    public <T> void until(final Callable<T> supplier, final Matcher<? super T> matcher) {
-        until(new CallableHamcrestCondition<T>(supplier, matcher, generateConditionSettings()));
+    public <T> T until(final Callable<T> supplier, final Matcher<? super T> matcher) {
+        return until(new CallableHamcrestCondition<T>(supplier, matcher, generateConditionSettings()));
     }
 
     /**
@@ -428,8 +428,8 @@ public class ConditionFactory {
      * @throws Exception
      *             the exception
      */
-    public void untilAtomic(final AtomicInteger atomic, final Matcher<? super Integer> matcher) {
-        until(new CallableHamcrestCondition<Integer>(new Callable<Integer>() {
+    public Integer untilAtomic(final AtomicInteger atomic, final Matcher<? super Integer> matcher) {
+        return until(new CallableHamcrestCondition<Integer>(new Callable<Integer>() {
             public Integer call() {
                 return atomic.get();
             }
@@ -452,8 +452,8 @@ public class ConditionFactory {
      * @throws Exception
      *             the exception
      */
-    public void untilAtomic(final AtomicLong atomic, final Matcher<? super Long> matcher) {
-        until(new CallableHamcrestCondition<Long>(new Callable<Long>() {
+    public Long untilAtomic(final AtomicLong atomic, final Matcher<? super Long> matcher) {
+        return until(new CallableHamcrestCondition<Long>(new Callable<Long>() {
             public Long call() {
                 return atomic.get();
             }
@@ -524,8 +524,8 @@ public class ConditionFactory {
      * @throws Exception
      *             the exception
      */
-    public <V> void untilAtomic(final AtomicReference<V> atomic, final Matcher<? super V> matcher) {
-        until(new CallableHamcrestCondition<V>(new Callable<V>() {
+    public <V> V untilAtomic(final AtomicReference<V> atomic, final Matcher<? super V> matcher) {
+        return until(new CallableHamcrestCondition<V>(new Callable<V>() {
             public V call() {
                 return atomic.get();
             }
@@ -568,8 +568,8 @@ public class ConditionFactory {
         return new ConditionSettings(alias, catchUncaughtExceptions, timeout, pollInterval, pollDelay);
     }
 
-    private <T> void until(Condition condition) {
-        condition.await();
+    private <T> T until(Condition<T> condition) {
+        return condition.await();
     }
 
     /**


### PR DESCRIPTION
There are situations where it would be useful to work with the result of a hamcrest condition. Currently this is impossible without calling the supplier again, which may have a different state than when the matcher was satisfied. In situations where the supplier would return the same result, then this is simply nice sugar.

Passes all unit tests, though I would like to write some more to test this functionality, pending comments on this change.

Also, this would fix https://code.google.com/p/awaitility/issues/detail?id=13.
