### PR TITLE
Automatic Deadlock Detection

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/core/DeadlockException.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/DeadlockException.java
@@ -1,0 +1,37 @@
+package com.jayway.awaitility.core;
+
+import java.lang.Throwable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+
+/**
+ * A {@link Throwable} used as a cause if deadlocked threads are detected by Awaitility.
+ */
+public class DeadlockException extends Throwable {
+
+    private final ThreadInfo[] threadInfos;
+
+    public DeadlockException(long[] threads) {
+        super("Deadlocked threads detected");
+
+        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+        threadInfos = bean.getThreadInfo(threads, true, true);
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(super.getMessage()).append(":\n\n");
+
+        for (ThreadInfo info : threadInfos)
+            sb.append(info.toString());
+
+        return sb.toString();
+    }
+
+    public ThreadInfo[] getThreadInfos() {
+        return Arrays.copyOf(threadInfos, threadInfos.length);
+    }
+}

--- a/awaitility/src/test/java/com/jayway/awaitility/DeadlockDetectionTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/DeadlockDetectionTest.java
@@ -1,0 +1,64 @@
+package com.jayway.awaitility;
+
+import com.jayway.awaitility.core.ConditionTimeoutException;
+import com.jayway.awaitility.core.DeadlockException;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DeadlockDetectionTest {
+
+    @Test(timeout = 2000L)
+    public void deadlockTest() throws Exception {
+        final Object lock1 = new Object();
+        final Object lock2 = new Object();
+
+        final AtomicBoolean locked = new AtomicBoolean();
+
+        Thread t1 = new Thread() {
+            public void run() {
+                synchronized(lock1) {
+                    try{
+                        Thread.sleep(50);
+                    } catch (InterruptedException ignored) {}
+
+                    synchronized(lock2) {
+                        locked.set(true);
+                    }
+                }
+            }
+        };
+
+        Thread t2 = new Thread(){
+            public void run(){
+                synchronized(lock2) {
+                    try{
+                        Thread.sleep(50);
+                    } catch (InterruptedException ignored) {}
+
+                    synchronized(lock1) {
+                        locked.set(true);
+                    }
+                }
+            }
+        };
+
+        t1.start();
+        t2.start();
+
+        try {
+            await().atMost(Duration.ONE_SECOND).untilTrue(locked);
+            fail("ConditionTimeoutException expected.");
+
+        } catch (ConditionTimeoutException e) {
+            DeadlockException cause = (DeadlockException) e.getCause();
+            assertTrue(cause instanceof DeadlockException);
+            assertEquals(2, cause.getThreadInfos().length);
+        }
+    }
+}


### PR DESCRIPTION
This code will check for deadlocked threads if a `ConditionTimeoutException` is thrown and attaches the thread information to the exception if something is detected.

The included `DeadlockDetectionTest` will cause the following exception:

```
com.jayway.awaitility.core.ConditionTimeoutException: com.jayway.awaitility.core.ConditionFactory.untilAtomic Callable expected (<true> or <true>) but was <false> within 1 seconds.
    at com.jayway.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:96)
    at com.jayway.awaitility.core.AbstractHamcrestCondition.await(AbstractHamcrestCondition.java:136)
    at com.jayway.awaitility.core.ConditionFactory.until(ConditionFactory.java:590)
    at com.jayway.awaitility.core.ConditionFactory.untilAtomic(ConditionFactory.java:505)
    at com.jayway.awaitility.core.ConditionFactory.untilTrue(ConditionFactory.java:519)
    at com.jayway.awaitility.DeadlockDetectionTest.atomicBooleanExample(DeadlockDetectionTest.java:55)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.internal.runners.statements.FailOnTimeout$StatementThread.run(FailOnTimeout.java:62)
Caused by: com.jayway.awaitility.core.DeadlockException: Deadlocked threads detected:

"Thread-2" Id=11 BLOCKED on java.lang.Object@72fb24c owned by "Thread-1" Id=10
    at com.jayway.awaitility.DeadlockDetectionTest$2.run(DeadlockDetectionTest.java:45)
    -  blocked on java.lang.Object@72fb24c
    -  locked java.lang.Object@6273e11a

"Thread-1" Id=10 BLOCKED on java.lang.Object@6273e11a owned by "Thread-2" Id=11
    at com.jayway.awaitility.DeadlockDetectionTest$1.run(DeadlockDetectionTest.java:31)
    -  blocked on java.lang.Object@6273e11a
    -  locked java.lang.Object@72fb24c


    at com.jayway.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:101)
    ... 14 more
```
