### PR TITLE
DeadlockDetectionTest: Cleanup threads after testrun

### DIFF
--- a/awaitility/src/test/java/com/jayway/awaitility/DeadlockDetectionTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/DeadlockDetectionTest.java
@@ -4,7 +4,9 @@ import com.jayway.awaitility.core.ConditionTimeoutException;
 import com.jayway.awaitility.core.DeadlockException;
 import org.junit.Test;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -15,35 +17,42 @@ public class DeadlockDetectionTest {
 
     @Test(timeout = 2000L)
     public void deadlockTest() throws Exception {
-        final Object lock1 = new Object();
-        final Object lock2 = new Object();
+        final ReentrantLock lock1 = new ReentrantLock();
+        final ReentrantLock lock2 = new ReentrantLock();
 
         final AtomicBoolean locked = new AtomicBoolean();
 
-        Thread t1 = new Thread() {
+        final Thread t1 = new Thread() {
             public void run() {
-                synchronized(lock1) {
-                    try{
+                lock1.lock();
+                try {
+                    try {
                         Thread.sleep(50);
-                    } catch (InterruptedException ignored) {}
 
-                    synchronized(lock2) {
+                        // wait for lock2 or external interrupt() call
+                        lock2.lockInterruptibly();
                         locked.set(true);
+                    } catch (InterruptedException ignored) {
                     }
+                } finally {
+                    lock1.unlock();
                 }
             }
         };
 
-        Thread t2 = new Thread(){
-            public void run(){
-                synchronized(lock2) {
-                    try{
+        final Thread t2 = new Thread(){
+            public void run() {
+                lock2.lock();
+                try {
+                    try {
                         Thread.sleep(50);
-                    } catch (InterruptedException ignored) {}
 
-                    synchronized(lock1) {
+                        // wait for lock1 or external interrupt() call
+                        lock1.lockInterruptibly();
                         locked.set(true);
-                    }
+                    } catch (InterruptedException ignored) {}
+                } finally {
+                    lock2.unlock();
                 }
             }
         };
@@ -55,7 +64,7 @@ public class DeadlockDetectionTest {
         try {
             // wait for something that will never happen
             // i.e. something that will throw the expected ConditionTimeoutException
-            await().atMost(Duration.ONE_SECOND).untilTrue(locked);
+            await().atMost(Duration.TWO_HUNDRED_MILLISECONDS).untilTrue(locked);
 
             // ... and fail if the exception is not thrown
             fail("ConditionTimeoutException expected.");
@@ -65,6 +74,18 @@ public class DeadlockDetectionTest {
             DeadlockException cause = (DeadlockException) e.getCause();
             assertTrue(cause instanceof DeadlockException);
             assertEquals(2, cause.getThreadInfos().length);
+
+        } finally {
+            // interrupt both threads to clean up the JVM
+            t1.interrupt();
+            t2.interrupt();
+
+            // wait until both threads are finished
+            await().atMost(Duration.ONE_SECOND).until(new Callable<Boolean>() {
+                public Boolean call() throws Exception {
+                    return !t1.isAlive() && !t2.isAlive();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
With the previous test code the threads will stay in deadlock forever until the JVM is killed. The new code uses Locks that can be interrupted instead, so that thread cleanup is possible after the test run.

Due to the different locking semantics the exception output is now:

```
com.jayway.awaitility.core.ConditionTimeoutException: com.jayway.awaitility.core.ConditionFactory.untilAtomic Callable expected (<true> or <true>) but was <false> within 200 milliseconds.
    at com.jayway.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:96)
    at com.jayway.awaitility.core.AbstractHamcrestCondition.await(AbstractHamcrestCondition.java:136)
    at com.jayway.awaitility.core.ConditionFactory.until(ConditionFactory.java:590)
    at com.jayway.awaitility.core.ConditionFactory.untilAtomic(ConditionFactory.java:505)
    at com.jayway.awaitility.core.ConditionFactory.untilTrue(ConditionFactory.java:519)
    at com.jayway.awaitility.DeadlockDetectionTest.deadlockTest(DeadlockDetectionTest.java:67)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.internal.runners.statements.FailOnTimeout$StatementThread.run(FailOnTimeout.java:62)
Caused by: com.jayway.awaitility.core.DeadlockException: Deadlocked threads detected:

"Thread-2" Id=11 WAITING on java.util.concurrent.locks.ReentrantLock$NonfairSync@35369763 owned by "Thread-1" Id=10
    at sun.misc.Unsafe.park(Native Method)
    -  waiting on java.util.concurrent.locks.ReentrantLock$NonfairSync@35369763
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:834)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireInterruptibly(AbstractQueuedSynchronizer.java:894)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1221)
    at java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:340)
    at com.jayway.awaitility.DeadlockDetectionTest$2.run(DeadlockDetectionTest.java:51)

    Number of locked synchronizers = 1
    - java.util.concurrent.locks.ReentrantLock$NonfairSync@4e19e97b

"Thread-1" Id=10 WAITING on java.util.concurrent.locks.ReentrantLock$NonfairSync@4e19e97b owned by "Thread-2" Id=11
    at sun.misc.Unsafe.park(Native Method)
    -  waiting on java.util.concurrent.locks.ReentrantLock$NonfairSync@4e19e97b
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:834)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireInterruptibly(AbstractQueuedSynchronizer.java:894)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1221)
    at java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:340)
    at com.jayway.awaitility.DeadlockDetectionTest$1.run(DeadlockDetectionTest.java:33)

    Number of locked synchronizers = 1
    - java.util.concurrent.locks.ReentrantLock$NonfairSync@35369763


    at com.jayway.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:101)
    ... 14 more
```
