### PR TITLE
Fix wrong method called for conditionEvaluationHandler

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/core/AssertionCondition.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/AssertionCondition.java
@@ -51,7 +51,7 @@ public class AssertionCondition implements Condition<Void> {
                     return true;
                 } catch (AssertionError e) {
                     lastExceptionMessage = e.getMessage();
-                    conditionEvaluationHandler.handleConditionResultMatch(getMismatchMessage(supplier), lastExceptionMessage);
+                    conditionEvaluationHandler.handleConditionResultMismatch(getMismatchMessage(supplier), lastExceptionMessage);
                     return false;
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.jayway.awaitility</groupId>
     <artifactId>awaitility-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.6.2-TOUK-1</version>
     <url>http://github.com/jayway/awaitility</url>
     <name>Awaitility Parent POM</name>
     <description>A Java DSL for synchronizing asynchronous operations</description>


### PR DESCRIPTION
I was so enthusiastic that conditionEvaluationHandler works, but I've missed this one. Sorry.
