### PR TITLE
Gracefully handle findDeadLockedThreads() not supported

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionAwaiter.java
@@ -96,9 +96,15 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                     ConditionTimeoutException e = new ConditionTimeoutException(message);
 
                     ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-                    long[] threadIds = bean.findDeadlockedThreads();
-                    if (threadIds != null)
-                        e.initCause(new DeadlockException(threadIds));
+                    try {
+                        long[] threadIds = bean.findDeadlockedThreads();
+                        if (threadIds != null)
+                            e.initCause(new DeadlockException(threadIds));
+                    }
+                    catch (UnsupportedOperationException ignored) {
+                        // findDeadLockedThreads() not supported on this VM,
+                        // don't init cause and move on.
+                    }
 
                     throw e;
                 }


### PR DESCRIPTION
So I'm using awaitility in a JVM where for various reasons [ThreadMXBean.findDeadLockedThreads() is not supported](http://docs.oracle.com/javase/7/docs/api/java/lang/management/ThreadMXBean.html#findDeadlockedThreads%28%29). Because of this, on timeouts, await() throws UnsupportedOperationException instead of the expected ConditionTimeoutException with a nice message.

This changeset should fix the issue by catching the UnsupportedOperationException and in this case, well, too bad, we won't be able to find which threads are deadlocked, but we can still throw the timeout exception anyway.
