### PR TITLE
Shade CGLib dependency and upgrade version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 .project
 .settings
 .springBeans
+*/dependency-reduced-pom.xml

--- a/awaitility/pom.xml
+++ b/awaitility/pom.xml
@@ -28,9 +28,41 @@
 	<description>A Java DSL for synchronizing asynchronous operations</description>
     <properties>
         <hamcrest.version>1.3</hamcrest.version>
+        <cglib.version>3.2.4</cglib.version>
     </properties>
 	<build>
 		<plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>cglib:cglib-nodep</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>net.sf.cglib</pattern>
+                            <shadedPattern>org.awaitility.cglib</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>cglib:cglib-nodep</artifact>
+                            <excludes>
+                                <exclude>META-INF/</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -61,7 +93,7 @@
 		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib-nodep</artifactId>
-			<version>3.1</version>
+			<version>${cglib.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.objenesis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,10 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.4.3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This PR resolves #55 by shading CGLib into the awaitility JAR.
CGLib version upgrade to `3.2.4`.
CGLib package is shaded under `org.awaitility.cglib` and all classes referencing it are replaced in the `package` phase.