### PR TITLE
Removing Duration.SAME_AS_POLL_INTERVAL.

### DIFF
--- a/awaitility/src/main/java/org/awaitility/Duration.java
+++ b/awaitility/src/main/java/org/awaitility/Duration.java
@@ -87,13 +87,7 @@ public class Duration implements Comparable<Duration> {
      * Constant <code>TEN_MINUTES</code>
      */
     public static final Duration TEN_MINUTES = new Duration(600, SECONDS);
-    /**
-     * Constant <code>SAME_AS_POLL_INTERVAL</code>
-     *
-     * @deprecated This doesn't do anything. The initial delay is now always the same as poll interval if nothing else is specified.
-     */
-    @Deprecated
-    public static final Duration SAME_AS_POLL_INTERVAL = new Duration();
+
     private static final int NONE = -1;
 
     private final long value;
@@ -342,8 +336,6 @@ public class Duration implements Comparable<Duration> {
         public final Duration apply(Duration lhs, Duration rhs) {
             if (lhs == null || rhs == null) {
                 throw new IllegalArgumentException("Duration cannot be null");
-            } else if (lhs == SAME_AS_POLL_INTERVAL || rhs == SAME_AS_POLL_INTERVAL) {
-                throw new IllegalStateException("Cannot perform operation on this kind of duration (SAME_AS_POLL_INTERVAL). Please don't use this Duration since it's deprecated");
             }
 
             Duration specialDuration = handleSpecialCases(lhs, rhs);

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -80,8 +80,6 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                 if (maxWaitTime == Duration.FOREVER) {
                     latch.await();
                     finishedBeforeTimeout = true;
-                } else if (maxWaitTime == Duration.SAME_AS_POLL_INTERVAL) {
-                    throw new IllegalStateException("Cannot use 'SAME_AS_POLL_INTERVAL' as maximum wait time.");
                 } else {
                     finishedBeforeTimeout = latch.await(maxTimeout, maxTimeoutUnit);
                 }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -34,10 +34,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.concurrent.TimeUnit.*;
 import static org.awaitility.Awaitility.*;
 import static org.awaitility.Duration.ONE_SECOND;
-import static org.awaitility.Duration.SAME_AS_POLL_INTERVAL;
-import static java.util.concurrent.TimeUnit.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -307,11 +306,6 @@ public class AwaitilityTest {
         await(alias).atMost(120, MILLISECONDS).untilCall(to(fakeRepository).getValue(), greaterThan(0));
     }
 
-    @SuppressWarnings("deprecation")
-    @Test(timeout = 2000, expected = IllegalStateException.class)
-    public void awaitWithSameAsPollIntervalThrowsIllegalStateException() throws Exception {
-        await().atMost(SAME_AS_POLL_INTERVAL).until(value(), greaterThan(0));
-    }
 
     @Test(timeout = 2000)
     public void awaitDisplaysSupplierAndMatcherNameWhenConditionTimeoutExceptionOccurs() throws Exception {


### PR DESCRIPTION
Duration.SAME_AS_POLL_INTERVAL has been deprecated before and using it does not work as expected anyway (the exception is thrown).

Code that starts throwing exception after migration from 1.5.0 

```
      Awaitility.await().atMost(Duration.FIVE_SECONDS)
                .pollInterval(Duration.ONE_HUNDRED_MILLISECONDS)
                .pollDelay(Duration.SAME_AS_POLL_INTERVAL)
                .until(() -> true);
```

the exception is 

```
Exception in thread "main" java.lang.IllegalArgumentException: Cannot delay polling forever
	at org.awaitility.core.ConditionFactory.generateConditionSettings(ConditionFactory.java:792)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:785)
	at MainClass.main(MainClass.java:14)
```


It seems to be better to get compilation error when migrating from an older version than to get exception during tests.

