### PR TITLE
Add openjdk6 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,14 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk7
+  - openjdk6
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+# use java 6 compatible maven version
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip
+  - unzip -qq apache-maven-3.2.5-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.2.5
+  - export PATH=$M2_HOME/bin:$PATH


### PR DESCRIPTION
Install open-jdk6 add-on

Install java 6 compatible maven version

It is possible that their is a better solution using docker and this change increases the complexity of the build so feel free to reject.