### PR TITLE
Throw TimeoutException from executing long-running Callables as ConditionTimeoutException

### DIFF
--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
@@ -229,6 +229,18 @@ public class AwaitilityJava8Test {
 
     }
 
+    // Asserts that https://github.com/awaitility/awaitility/issues/97 is resolved
+    @Test(timeout = 2000L)
+    public void longConditionThrowsConditionTimeoutException() throws Exception {
+        exception.expect(ConditionTimeoutException.class);
+        exception.expectMessage("Condition with org.awaitility.AwaitilityJava8Test was not fulfilled within 50 milliseconds.");
+
+        given().pollDelay(10, MILLISECONDS).await().atMost(50, MILLISECONDS).until(() -> {
+            Thread.sleep(1000);
+            return false;
+        });
+    }
+
     private void stringEquals(String first, String second) {
         Assertions.assertThat(first).isEqualTo(second);
     }

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -94,14 +95,12 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
             }
             evaluationDuration = calculateConditionEvaluationDuration(pollDelay, pollingStarted);
             succeededBeforeTimeout = maxWaitTime.compareTo(evaluationDuration) > 0;
-        } catch (Throwable e1) {
-            final Throwable throwable;
-            if (e1 instanceof ExecutionException) {
-                throwable = e1.getCause();
-            } else {
-                throwable = e1;
-            }
-            lastResult = new ConditionEvaluationResult(false, throwable, null);
+        } catch (TimeoutException e) {
+            lastResult = new ConditionEvaluationResult(false, null, e);
+        } catch (ExecutionException e) {
+            lastResult = new ConditionEvaluationResult(false, e.getCause(), null);
+        } catch (Throwable e) {
+            lastResult = new ConditionEvaluationResult(false, e, null);
         }
 
         try {


### PR DESCRIPTION
Submitting a long-running `Callable` to Awaitility means that it can time out and throw `TimeoutException` rather than `ConditionTimeoutException` in `ConditionAwaiter.await()` (see https://github.com/awaitility/awaitility/issues/97). This wasn't something I expected from reading Awaitility's Javadoc and it intermittently broke some of my code that wasn't expecting this exception.

I made a change to specifically catch the `TimeoutException` and ensure that it goes through to be thrown as a `ConditionTimeoutException` by setting the `throwable` second parameter of the `ConditionEvaluationResult` constructor to `null`.