### PR TITLE
[WIP] Issue-48: Allow users to set an onTimeout callback, overriding the de…

### DIFF
--- a/awaitility/src/main/java/org/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/org/awaitility/Awaitility.java
@@ -110,6 +110,11 @@ public class Awaitility {
     private static final Duration DEFAULT_POLL_DELAY = null;
 
     private static final PollInterval DEFAULT_POLL_INTERVAL = new FixedPollInterval(ONE_HUNDRED_MILLISECONDS);
+    
+    /**
+     * The default method to call on timeout.
+     */
+    private static final Consumer<OnTimeoutContext> DEFAULT_ON_TIMEOUT_CALLBACK = new ConditionTimeoutExceptionThrowingOnTimeoutCallback();
 
     /**
      * The default poll interval (fixed 100 ms).
@@ -314,7 +319,7 @@ public class Awaitility {
      */
     public static ConditionFactory await(String alias) {
         return new ConditionFactory(alias, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -327,7 +332,7 @@ public class Awaitility {
      */
     public static ConditionFactory catchUncaughtExceptions() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -339,7 +344,7 @@ public class Awaitility {
      */
     public static ConditionFactory dontCatchUncaughtExceptions() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
-                false, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, false, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -354,7 +359,7 @@ public class Awaitility {
      */
     public static ConditionFactory with() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -369,7 +374,7 @@ public class Awaitility {
      */
     public static ConditionFactory given() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -382,7 +387,7 @@ public class Awaitility {
      */
     public static ConditionFactory waitAtMost(Duration timeout) {
         return new ConditionFactory(null, defaultWaitConstraint.withMaxWaitTime(timeout), defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 
@@ -396,7 +401,7 @@ public class Awaitility {
      */
     public static ConditionFactory waitAtMost(long value, TimeUnit unit) {
         return new ConditionFactory(null, defaultWaitConstraint.withMaxWaitTime(new Duration(value, unit)), defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
+                DEFAULT_ON_TIMEOUT_CALLBACK, defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
                 defaultExecutorLifecycle);
     }
 

--- a/awaitility/src/main/java/org/awaitility/core/AssertionErrorThrowingOnTimeoutCallback.java
+++ b/awaitility/src/main/java/org/awaitility/core/AssertionErrorThrowingOnTimeoutCallback.java
@@ -1,0 +1,14 @@
+
+package org.awaitility.core;
+
+public class AssertionErrorThrowingOnTimeoutCallback implements Consumer<OnTimeoutContext> {
+    
+    private final DefaultTimeoutMessageBuilder messageBuilder = new DefaultTimeoutMessageBuilder();
+    
+    @Override
+    public void accept(OnTimeoutContext ctx) {
+        String message = messageBuilder.getTimeoutErrorMessage(ctx);
+        throw new AssertionError(message, ctx.getCause().orElse(null));
+    }
+    
+}

--- a/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
@@ -24,6 +24,7 @@ public class ConditionSettings {
     private final WaitConstraint waitConstraint;
     private final PollInterval pollInterval;
     private final Duration pollDelay;
+    private final Consumer<OnTimeoutContext> onTimeoutCallback;
     private final boolean catchUncaughtExceptions;
     private final ExceptionIgnorer ignoreExceptions;
     private final ConditionEvaluationListener conditionEvaluationListener;
@@ -37,13 +38,15 @@ public class ConditionSettings {
      * @param waitConstraint              a {@link org.awaitility.constraint.WaitConstraint} object.
      * @param pollInterval                a {@link org.awaitility.Duration} object.
      * @param pollDelay                   a {@link org.awaitility.Duration} object.
+     * @param onTimeoutCallback           The callback to call on timeout
      * @param conditionEvaluationListener a {@link ConditionEvaluationListener} object.
      * @param ignoreExceptions            a {@link ExceptionIgnorer} object.
      * @param executorLifecycle           Responsible for performing executor service cleanup after each condition evaluation round
      */
     ConditionSettings(String alias, boolean catchUncaughtExceptions, WaitConstraint waitConstraint,
-                      PollInterval pollInterval, Duration pollDelay, ConditionEvaluationListener conditionEvaluationListener,
-                      ExceptionIgnorer ignoreExceptions, ExecutorLifecycle executorLifecycle) {
+                      PollInterval pollInterval, Duration pollDelay, Consumer<OnTimeoutContext> onTimeoutCallback,
+                      ConditionEvaluationListener conditionEvaluationListener, ExceptionIgnorer ignoreExceptions,
+                      ExecutorLifecycle executorLifecycle) {
         if (waitConstraint == null) {
             throw new IllegalArgumentException("You must specify a maximum waiting time (was null).");
         }
@@ -55,6 +58,7 @@ public class ConditionSettings {
         this.waitConstraint = waitConstraint;
         this.pollInterval = pollInterval;
         this.pollDelay = pollDelay;
+        this.onTimeoutCallback = onTimeoutCallback;
         this.catchUncaughtExceptions = catchUncaughtExceptions;
         this.conditionEvaluationListener = conditionEvaluationListener;
         this.ignoreExceptions = ignoreExceptions;
@@ -103,6 +107,13 @@ public class ConditionSettings {
      */
     public Duration getPollDelay() {
         return pollDelay;
+    }
+
+    /**
+     * @return The callback to call on timeout
+     */
+    public Consumer<OnTimeoutContext> getOnTimeoutCallback() {
+        return onTimeoutCallback;
     }
 
     /**

--- a/awaitility/src/main/java/org/awaitility/core/ConditionTimeoutExceptionThrowingOnTimeoutCallback.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionTimeoutExceptionThrowingOnTimeoutCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.awaitility.core;
 
-/**
- * A consumer (because Awaitility doesn't require Java 8)
- *
- * @since 3.1.0
- */
-public interface Consumer<T> {
+public class ConditionTimeoutExceptionThrowingOnTimeoutCallback implements Consumer<OnTimeoutContext> {
 
-    /**
-     * Performs this operation on the given argument.
-     *
-     * @param t the input argument
-     */
-    void accept(T t);
+    private final DefaultTimeoutMessageBuilder messageBuilder = new DefaultTimeoutMessageBuilder();
+    
+    @Override
+    public void accept(OnTimeoutContext ctx) {
+        String message = messageBuilder.getTimeoutErrorMessage(ctx);
+        throw new ConditionTimeoutException(message, ctx.getCause().orElse(null));
+    }
+
 }

--- a/awaitility/src/main/java/org/awaitility/core/DefaultTimeoutMessageBuilder.java
+++ b/awaitility/src/main/java/org/awaitility/core/DefaultTimeoutMessageBuilder.java
@@ -1,0 +1,27 @@
+
+package org.awaitility.core;
+
+import org.awaitility.constraint.WaitConstraint;
+
+public class DefaultTimeoutMessageBuilder {
+
+    public String getTimeoutErrorMessage(OnTimeoutContext ctx) {
+        final String maxWaitTimeLowerCase = ctx.getMaxWaitTime().getTimeUnitAsString();
+        final long maxTimeout = ctx.getMaxWaitTime().getValue();
+        String timeoutMessage = ctx.getTimeoutMessage();
+        return ctx.getAlias()
+            .map(alias -> String.format("Condition with alias '%s' didn't complete within %s %s because %s.",
+                alias, maxTimeout, maxWaitTimeLowerCase, decapitalize(timeoutMessage)))
+            .orElse(String.format("%s within %s %s.", timeoutMessage, maxTimeout, maxWaitTimeLowerCase));
+    }
+    
+    private static String decapitalize(String str) {
+        if (str == null) {
+            return "";
+        }
+        String firstLetter = str.substring(0, 1).toLowerCase();
+        String restLetters = str.substring(1);
+        return firstLetter + restLetters;
+    }
+    
+}

--- a/awaitility/src/main/java/org/awaitility/core/OnTimeoutContext.java
+++ b/awaitility/src/main/java/org/awaitility/core/OnTimeoutContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.awaitility.core;
+
+import java.util.Optional;
+import org.awaitility.Duration;
+import org.awaitility.pollinterval.PollInterval;
+
+public class OnTimeoutContext {
+
+    private final String alias;
+    private final Duration maxWaitTime;
+    private final PollInterval pollInterval;
+    private final Duration pollDelay;
+    private final String timeoutMessage;
+    private final Throwable cause;
+    private final Duration evaluationDuration;
+
+    public OnTimeoutContext(String alias, Duration maxWaitTime, PollInterval pollInterval, Duration pollDelay, String timeoutMessage,
+        Throwable cause, Duration evaluationDuration) {
+        this.alias = alias;
+        this.maxWaitTime = maxWaitTime;
+        this.pollInterval = pollInterval;
+        this.pollDelay = pollDelay;
+        this.timeoutMessage = timeoutMessage;
+        this.cause = cause;
+        this.evaluationDuration = evaluationDuration;
+    }
+
+    public Optional<String> getAlias() {
+        return Optional.ofNullable(alias);
+    }
+
+    public Duration getMaxWaitTime() {
+        return maxWaitTime;
+    }
+
+    public PollInterval getPollInterval() {
+        return pollInterval;
+    }
+
+    public Duration getPollDelay() {
+        return pollDelay;
+    }
+
+    public String getTimeoutMessage() {
+        return timeoutMessage;
+    }
+
+    public Optional<Throwable> getCause() {
+        return Optional.ofNullable(cause);
+    }
+
+    public Duration getEvaluationDuration() {
+        return evaluationDuration;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
   <properties>
     <bytebuddy.version>1.7.0</bytebuddy.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <java.version>1.6</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
@@ -146,7 +146,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java18</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
…fault behavior of throwing ConditionTimeoutException

Closes https://github.com/awaitility/awaitility/issues/48.

This is a work in progress, I want to get feedback on this before making more changes.

As discussed on the issue thread, I've added an onTimeout method to the Awaitility API that lets users replace the default timeout handling behavior. The method lets the user set a callback method, which receives a context object containing various useful properties for e.g. constructing an error message.

The default timeout handling has been moved to a default callback, so there should be no behavioral changes unless users call onTimeout. I've added a convenience method for users (me) that want to make Awaitility throw AssertionError instead of ConditionTimeoutException. I'm happy to remove it if it isn't generally useful, since it is easy for users to implement on their own. 

The part that's missing would be adding a similar hook for the case where the statement finishes too soon (at https://github.com/awaitility/awaitility/blob/548bcc27326a2a91ffb30c2b192b2e285009f982/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java#L146). I think the best way to support that branch is to create an extra `onEarlyTermination` or something, since I think it will be irritating for people to have to check in `onTimeout` whether the statement finishes too early or late. I'll add that hook to this PR once the direction of these changes are approved.

I took a look at some other issues (notably https://github.com/awaitility/awaitility/issues/106, but there are others that are also blocked pending a Java upgrade), and got the impression that upgrading to Java 8 might be a possibility. Java 6/7 have been EOL'd for years now. That said, if upgrading the Java version is not an option I'll try to rework this to work with older versions.