### PR TITLE
upgraded hamcrest version

### DIFF
--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
@@ -237,7 +237,7 @@ public class AwaitilityJava8Test {
     @Test
     public void errorMessageLooksOkForHamcrestLambdaExpressionsWhoseMismatchDescriptionOriginallyIsEmptyStringByHamcrest() throws Exception {
         exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(endsWith("expected a collection containing a string ending with \"hello\" but was <[]> within 50 milliseconds."));
+        exception.expectMessage(endsWith("expected a collection containing a string ending with \"hello\" but was empty within 50 milliseconds."));
 
         // Given
         FakeRepositoryList fakeRepositoryList = new FakeRepositoryList();

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 
   <properties>
     <bytebuddy.version>1.7.0</bytebuddy.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.1</hamcrest.version>
     <java.version>1.6</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
We keep having to `<exclude>`hamcrest when we use awaitility because it's hamcrest version is out of date.  Please accept this pull request that updates hamcrest to the latest version.
