### PR TITLE
It seems that the issue with negative times in ConditionAwaiter has returned in 4.0.0

### DIFF
--- a/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
@@ -1,0 +1,23 @@
+
+package org.awaitility.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class ConditionAwaiterTest {
+
+
+    /**
+     * Asserts that https://github.com/awaitility/awaitility/issues/95 is resolved
+     */
+    @Test public void
+    calculates_a_duration_of_1_nano_when_system_nano_time_is_skewed() {
+        Duration duration = ConditionAwaiter.calculateConditionEvaluationDuration(Duration.ofNanos(10000000L), System.nanoTime());
+
+        assertThat(duration.toNanos(), is(1L));
+    }
+}


### PR DESCRIPTION
When i upgraded to 4.0.0 tests started to fail on windows with java 11. I tracked it down to an old fix that was made in #95. I see that that has since been removed and the tests aren't failing with version 3.1.6 even though the code looks the same as in 4.0.0 with the exception of switching to java 8+ Duration. This fixes the issue for me on windows.