### PR TITLE
Move test-only dependencies into test scope

### DIFF
--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>

--- a/awaitility-kotlin/pom.xml
+++ b/awaitility-kotlin/pom.xml
@@ -44,14 +44,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility-test-support</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/awaitility-scala/pom.xml
+++ b/awaitility-scala/pom.xml
@@ -36,17 +36,20 @@
             <version>${scala.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Test -->
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/awaitility/pom.xml
+++ b/awaitility/pom.xml
@@ -72,13 +72,16 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
+        <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility-test-support</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
While looking at [adding Awaitility to Spring Boot's dependency management](https://github.com/spring-projects/spring-boot/issues/18205) we noticed some dependencies on `junit:junit`. Upon closer inspection, it appears that those dependencies should be test-scoped. This pull request does just that and everything appears to build cleanly (mvn verify was successful at least).