### PR TITLE
Correct license URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <licenses>
         <license>
             <name>Apache 2.0</name>
-            <url>LICENSE.txt</url>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 


### PR DESCRIPTION
The license URL in the pom should be an actual URL. This is perhaps overly pedantic of me, but I noticed after adding awaitility to my project that it showed up in the broken links report for the maven site.

Here's a public example of the problem (not my usage): https://strengthened.github.io/prometheus-healthchecks/dependencies.html
* In the dependency list the license shows up as `LICENSE.txt`, no title, not a link.
* In the dependency graph, where nodes expand by clicking the icons, there's a link titled `Apache 2.0` but it links to LICENSE.txt in the generated site for that project, which doesn't exist.

Using a real URL solves both these issues.