### PR TITLE
Hold condition during a period of time

### DIFF
--- a/awaitility/src/main/java/org/awaitility/constraint/AtMostWaitConstraint.java
+++ b/awaitility/src/main/java/org/awaitility/constraint/AtMostWaitConstraint.java
@@ -24,11 +24,19 @@ public class AtMostWaitConstraint implements WaitConstraint {
         return Duration.ZERO;
     }
 
+    public Duration getHoldPredicateTime() {
+        return Duration.ZERO;
+    }
+
     public WaitConstraint withMinWaitTime(Duration minWaitTime) {
         return new IntervalWaitConstraint(minWaitTime, atMostDuration);
     }
 
     public WaitConstraint withMaxWaitTime(Duration maxWaitTime) {
         return new AtMostWaitConstraint(maxWaitTime);
+    }
+
+    public WaitConstraint withHoldPredicateTime(Duration holdConditionTime) {
+        return new HoldsPredicateWaitConstraint(getMinWaitTime(), atMostDuration, holdConditionTime);
     }
 }

--- a/awaitility/src/main/java/org/awaitility/constraint/HoldsPredicateWaitConstraint.java
+++ b/awaitility/src/main/java/org/awaitility/constraint/HoldsPredicateWaitConstraint.java
@@ -1,0 +1,22 @@
+package org.awaitility.constraint;
+
+import java.time.Duration;
+
+public class HoldsPredicateWaitConstraint extends IntervalWaitConstraint {
+  private final Duration holdConditionTime;
+
+  HoldsPredicateWaitConstraint(Duration atLeastConstraint, Duration atMostDuration, Duration holdConditionTime) {
+    super(atLeastConstraint, atMostDuration);
+    this.holdConditionTime = holdConditionTime;
+  }
+
+  @Override
+  public Duration getHoldPredicateTime() {
+    return holdConditionTime;
+  }
+
+  @Override
+  public WaitConstraint withHoldPredicateTime(Duration holdConditionTime) {
+    return new HoldsPredicateWaitConstraint(getMinWaitTime(), getMaxWaitTime(), holdConditionTime);
+  }
+}

--- a/awaitility/src/main/java/org/awaitility/constraint/HoldsPredicateWaitConstraint.java
+++ b/awaitility/src/main/java/org/awaitility/constraint/HoldsPredicateWaitConstraint.java
@@ -19,4 +19,15 @@ public class HoldsPredicateWaitConstraint extends IntervalWaitConstraint {
   public WaitConstraint withHoldPredicateTime(Duration holdConditionTime) {
     return new HoldsPredicateWaitConstraint(getMinWaitTime(), getMaxWaitTime(), holdConditionTime);
   }
+
+  @Override
+  public WaitConstraint withMaxWaitTime(Duration maxWaitTime) {
+    return new HoldsPredicateWaitConstraint(getMinWaitTime(), maxWaitTime, holdConditionTime);
+  }
+
+  @Override
+  public WaitConstraint withMinWaitTime(Duration minWaitTime) {
+    return new HoldsPredicateWaitConstraint(minWaitTime, getMaxWaitTime(), holdConditionTime);
+  }
+
 }

--- a/awaitility/src/main/java/org/awaitility/constraint/WaitConstraint.java
+++ b/awaitility/src/main/java/org/awaitility/constraint/WaitConstraint.java
@@ -15,7 +15,11 @@ public interface WaitConstraint {
 
     Duration getMinWaitTime();
 
+    Duration getHoldPredicateTime();
+
     WaitConstraint withMinWaitTime(Duration minWaitTime);
 
     WaitConstraint withMaxWaitTime(Duration maxWaitTime);
+
+    WaitConstraint withHoldPredicateTime(Duration holdConditionTime);
 }

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -99,7 +99,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                 } else if (lastResult.isError()) {
                     firstSucceedSinceStarted = 0L;
                 }
-                if (lastResult.isSuccessful() && (System.nanoTime() - firstSucceedSinceStarted > holdPredicateWaitTime.toNanos() ) || lastResult.hasThrowable()) {
+                if (lastResult.isSuccessful() && (System.nanoTime() - firstSucceedSinceStarted >= holdPredicateWaitTime.toNanos() ) || lastResult.hasThrowable()) {
                     break;
                 }
                 pollInterval = conditionSettings.getPollInterval().next(pollCount, pollInterval);

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -67,6 +67,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
         final Duration pollDelay = conditionSettings.getPollDelay();
         final Duration maxWaitTime = conditionSettings.getMaxWaitTime();
         final Duration minWaitTime = conditionSettings.getMinWaitTime();
+        final Duration holdPredicateWaitTime = conditionSettings.getHoldPredicateTime();
 
         long pollingStartedNanos = System.nanoTime() - pollDelay.toMillis();
 
@@ -75,6 +76,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
         ConditionEvaluationResult lastResult = null;
         Duration evaluationDuration = Duration.of(0, MILLIS);
         Future<ConditionEvaluationResult> currentConditionEvaluation = null;
+        long firstSucceedSinceStarted = 0L;
         try {
             if (executor.isShutdown() || executor.isTerminated()) {
                 throw new IllegalStateException("The executor service that Awaitility is instructed to use has been shutdown so condition evaluation cannot be performed. Is there something wrong the thread or executor configuration?");
@@ -92,7 +94,12 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                 currentConditionEvaluation = executor.submit(new ConditionPoller(pollInterval));
                 // Wait for condition evaluation to complete with "maxWaitTimeForThisCondition" or else throw TimeoutException
                 lastResult = ChronoUnit.FOREVER.getDuration().equals(maxWaitTime) ? getUninterruptibly(currentConditionEvaluation) : getUninterruptibly(currentConditionEvaluation, maxWaitTimeForThisCondition);
-                if (lastResult.isSuccessful() || lastResult.hasThrowable()) {
+                if (lastResult.isSuccessful() && firstSucceedSinceStarted == 0L) {
+                    firstSucceedSinceStarted = System.nanoTime();
+                } else if (lastResult.isError()) {
+                    firstSucceedSinceStarted = 0L;
+                }
+                if (lastResult.isSuccessful() && (System.nanoTime() - firstSucceedSinceStarted > holdPredicateWaitTime.toNanos() ) || lastResult.hasThrowable()) {
                     break;
                 }
                 pollInterval = conditionSettings.getPollInterval().next(pollCount, pollInterval);

--- a/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
@@ -148,6 +148,28 @@ public class ConditionFactory {
     }
 
     /**
+     * Await at the predicate holds during at least <code>timeout</code>
+     *
+     * @param timeout the timeout
+     * @return the condition factory
+     */
+    public ConditionFactory during(Duration timeout) {
+        return new ConditionFactory(alias, timeoutConstraint.withHoldPredicateTime(timeout), pollInterval, pollDelay,
+            catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle);
+    }
+
+    /**
+     * Await at the predicate holds during at least <code>timeout</code>
+     *
+     * @param timeout the timeout
+     * @param unit    the unit
+     * @return the condition factory
+     */
+    public ConditionFactory during(long timeout, TimeUnit unit) {
+        return during(DurationFactory.of(timeout, unit));
+    }
+
+    /**
      * Set the alias
      *
      * @param alias alias

--- a/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
@@ -89,6 +89,15 @@ public class ConditionSettings {
     }
 
     /**
+     * <p>Returning hold predicate wait time from field <code>waitConstraint</code>.</p>
+     *
+     * @return a {@link org.awaitility.Duration} object.
+     */
+    public Duration getHoldPredicateTime() {
+        return waitConstraint.getHoldPredicateTime();
+    }
+
+    /**
      * <p>Getter for the field <code>pollInterval</code>.</p>
      *
      * @return a {@link org.awaitility.Duration} object.

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runners.model.TestTimedOutException;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -429,14 +430,47 @@ public class AwaitilityTest {
     }
 
     @Test(timeout = 2000L)
-    public void awaitDuringTimeOnCondition() {
-        await().atLeast(1, SECONDS)
-            .until(() -> {
-                await()
-                    .during(1, SECONDS)
-                    .until(() -> true);
-                return true;
-            });
+    public void awaitDuringTimeOnCondition() throws Exception {
+        Duration duration = measureDuration(() ->
+            await()
+                .during(1, SECONDS)
+                .until(() -> true)
+        );
+
+        assertThat(duration.toMillis(), greaterThan(1000L));
+    }
+
+    @Test(timeout = 2500L)
+    public void awaitDuringTimeWillWaitTheTimeStartingWhenTheConditionHolds() throws Exception {
+        long startTime = System.currentTimeMillis();
+
+        Duration duration = measureDuration(() ->
+            await()
+                .during(1000, MILLISECONDS)
+                .until(() ->
+                    (System.currentTimeMillis() - startTime) > 500L
+                )
+        );
+
+        assertThat(duration.toMillis(), greaterThan(1500L));
+    }
+
+    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
+    public void awaitDuringTimeWillThrowExceptionWhenTimeOut() {
+        await()
+            .atMost(1000, MILLISECONDS)
+            .during(200, MILLISECONDS)
+            .until(() -> false);
+    }
+
+    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
+    public void awaitDuringTimeWillThrowExceptionWhenTimeOutEvenIfConditionIsOkAtTheEndButNotDuringPeriod() {
+        long startTime = System.currentTimeMillis();
+
+        await()
+            .atMost(1500, MILLISECONDS)
+            .during(1000, MILLISECONDS)
+            .until(() -> (System.currentTimeMillis() - startTime) > 1000L);
     }
 
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {
@@ -468,5 +502,17 @@ public class AwaitilityTest {
 
     private Callable<List<Integer>> valueAsList() {
         return () -> Collections.singletonList(fakeRepository.getValue());
+    }
+
+    @FunctionalInterface
+    interface ActionWithException {
+        void action() throws Exception;
+    }
+    private Duration measureDuration(ActionWithException a) throws Exception {
+        Instant init = Instant.now();
+
+        a.action();
+
+        return Duration.between(init, Instant.now());
     }
 }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -428,6 +428,17 @@ public class AwaitilityTest {
                 });
     }
 
+    @Test(timeout = 2000L)
+    public void awaitDuringTimeOnCondition() {
+        await().atLeast(1, SECONDS)
+            .until(() -> {
+                await()
+                    .during(1, SECONDS)
+                    .until(() -> true);
+                return true;
+            });
+    }
+
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {
         return new FakeRepositoryEqualsOne(fakeRepository);
     }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -473,6 +473,20 @@ public class AwaitilityTest {
             .until(() -> (System.currentTimeMillis() - startTime) > 1000L);
     }
 
+    @Test(timeout = 2000L)
+    public void awaitDuringTimeOnConditionMessingAtLeastAtMost() throws Exception {
+        Duration duration = measureDuration(() ->
+            await()
+                .during(1, SECONDS)
+                .during(1, SECONDS)
+                .atLeast(1, SECONDS)
+                .atMost(2, SECONDS)
+                .until(() -> true)
+        );
+
+        assertThat(duration.toMillis(), greaterThan(1000L));
+    }
+
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {
         return new FakeRepositoryEqualsOne(fakeRepository);
     }


### PR DESCRIPTION
Allows to check if a condition is maintained during a period of time:

```
await().during(5, TimeUnit.SECONDS).until(this::testConditionA);
```
Check how It looks like the solution, not very happy with current implementation, but the idea is having a wait to tell the time the condition should hold.

A lot more of testing is also needed ;)

Closes  #124 