### PR TITLE
Notify on "start waiting" and on "timed out"

### DIFF
--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -152,10 +152,12 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                         // don't init trace and move on.
                     }
                 }
+                conditionEvaluationHandler.handleTimeout(message, false);
                 throw new ConditionTimeoutException(message, cause);
             } else if (evaluationDuration.compareTo(minWaitTime) < 0) {
                 String message = String.format("Condition was evaluated in %s which is earlier than expected minimum timeout %s",
                         formatAsString(evaluationDuration), formatAsString(minWaitTime));
+                conditionEvaluationHandler.handleTimeout(message, true);
                 throw new ConditionTimeoutException(message);
             }
         } catch (Throwable e) {

--- a/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationHandler.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationHandler.java
@@ -83,7 +83,26 @@ class ConditionEvaluationHandler<T> {
     }
 
     public void start() {
+
+        ConditionEvaluationListener<T> listener = settings.getConditionEvaluationListener();
+        if (listener != null) {
+            long elapsedTimeInMS = 0L;
+            long remainingTimeInMS = getRemainingTimeInMS(0, settings.getMaxWaitTime());
+
+            listener.beforeEvaluation(new StartEvaluationEvent<>("Starting evaluation", matcher, elapsedTimeInMS,
+                    remainingTimeInMS, settings.getAlias()));
+        }
         watch.start();
+    }
+
+    public void handleTimeout(String message, boolean isConditionSatisfied) {
+        ConditionEvaluationListener<T> listener = settings.getConditionEvaluationListener();
+        if (listener != null) {
+            long elapsedTimeInMS = watch.getElapsedTimeInMS();
+            long remainingTimeInMS = getRemainingTimeInMS(elapsedTimeInMS, settings.getMaxWaitTime());
+            listener.onTimeout(new TimeoutEvent(message, elapsedTimeInMS, remainingTimeInMS,
+                    isConditionSatisfied, settings.getAlias()));
+        }
     }
 
     private static class StopWatch {

--- a/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationListener.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationListener.java
@@ -20,6 +20,7 @@ package org.awaitility.core;
  *
  * @param <T> The expected return type of the condition
  */
+@FunctionalInterface
 public interface ConditionEvaluationListener<T> {
 
     /**
@@ -28,4 +29,18 @@ public interface ConditionEvaluationListener<T> {
      * @param condition The condition evaluation result containing various properties of the result of evaluated condition
      */
     void conditionEvaluated(EvaluatedCondition<T> condition);
+
+    /**
+     * Handle the startEvaluationEvent. Method is default to keep the ConditionEvaluationListener backward compatible.
+     *
+     * @param startEvaluationEvent the event containing various properties of the condition evaluation to be started
+     */
+    default void beforeEvaluation(StartEvaluationEvent<T> startEvaluationEvent) {}
+
+    /**
+     * Handle the timeoutEvent. Method is default to keep the ConditionEvaluationListener backward compatible.
+     *
+     * @param timeoutEvent the event containing some properties about the condition evaluation timeout
+     */
+    default void onTimeout(TimeoutEvent timeoutEvent) {}
 }

--- a/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationLogger.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationLogger.java
@@ -60,6 +60,16 @@ public class ConditionEvaluationLogger implements ConditionEvaluationListener<Ob
         }
     }
 
+    @Override
+    public void beforeEvaluation(StartEvaluationEvent<Object> condition) {
+        System.out.printf("%s", condition.getDescription());
+    }
+
+    @Override
+    public void onTimeout(TimeoutEvent timeoutEvent) {
+        System.out.printf("%s", timeoutEvent.getDescription());
+    }
+
     /**
      * Syntactic sugar to avoid writing the <code>new</code> keyword in Java.
      * Uses {@link java.util.concurrent.TimeUnit#MILLISECONDS} as unit for elapsed and remaining time.

--- a/awaitility/src/main/java/org/awaitility/core/StartEvaluationEvent.java
+++ b/awaitility/src/main/java/org/awaitility/core/StartEvaluationEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.awaitility.core;
+
+import org.hamcrest.Matcher;
+
+public class StartEvaluationEvent<T> {
+    private final String description;
+    private final Matcher<? super T> matcher;
+    private final long elapsedTimeInMS;
+    private final long remainingTimeInMS;
+    private final String alias;
+
+    /**
+     * @param description           description message of the event
+     * @param matcher               The Hamcrest matcher used in the condition
+     * @param elapsedTimeInMS       elapsed time in milliseconds.
+     * @param remainingTimeInMS     remaining time to wait in milliseconds; <code>Long.MAX_VALUE</code>, if no timeout defined, i.e., running forever.
+     */
+    StartEvaluationEvent(String description, Matcher<? super T> matcher, long elapsedTimeInMS, long remainingTimeInMS,
+                         String alias) {
+        this.description = description;
+        this.matcher = matcher;
+        this.elapsedTimeInMS = elapsedTimeInMS;
+        this.remainingTimeInMS = remainingTimeInMS;
+        this.alias = alias;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Matcher<? super T> getMatcher() {
+        return matcher;
+    }
+
+    public long getElapsedTimeInMS() {
+        return elapsedTimeInMS;
+    }
+
+    public long getRemainingTimeInMS() {
+        return remainingTimeInMS;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+}

--- a/awaitility/src/main/java/org/awaitility/core/TimeoutEvent.java
+++ b/awaitility/src/main/java/org/awaitility/core/TimeoutEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.awaitility.core;
+
+public class TimeoutEvent {
+
+    private final String description;
+    private final long elapsedTimeInMS;
+    private final long remainingTimeInMS;
+    private final boolean conditionIsFulfilled;
+    private final String alias;
+
+    public TimeoutEvent(String description, long elapsedTimeInMS, long remainingTimeInMS, boolean conditionIsFulfilled, String alias) {
+        this.description = description;
+        this.elapsedTimeInMS = elapsedTimeInMS;
+        this.remainingTimeInMS = remainingTimeInMS;
+        this.conditionIsFulfilled = conditionIsFulfilled;
+        this.alias = alias;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public long getElapsedTimeInMS() {
+        return elapsedTimeInMS;
+    }
+
+    public long getRemainingTimeInMS() {
+        return remainingTimeInMS;
+    }
+
+    public boolean isConditionIsFulfilled() {
+        return conditionIsFulfilled;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+}

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -16,8 +16,11 @@
 package org.awaitility;
 
 import org.awaitility.classes.*;
+import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.EvaluatedCondition;
 import org.awaitility.core.ForeverDuration;
+import org.awaitility.core.TimeoutEvent;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -174,6 +177,22 @@ public class AwaitilityTest {
         new Asynch(fakeRepository).perform();
         await().atMost(200, TimeUnit.MILLISECONDS).until(value(), equalTo(1));
         assertEquals(1, fakeRepository.getValue());
+    }
+
+    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
+    public void remainingTimeIsNegativeAfterDurationTimeouts() {
+        new Asynch(fakeRepository).perform();
+        ConditionEvaluationListener conditionEvaluationListener = new ConditionEvaluationListener() {
+            @Override
+            public void conditionEvaluated(EvaluatedCondition condition) {
+            }
+
+            @Override
+            public void onTimeout(TimeoutEvent timeoutEvent) {
+                assertTrue(timeoutEvent.getRemainingTimeInMS() < 0L);
+            }
+        };
+        await().conditionEvaluationListener(conditionEvaluationListener).atMost(200, TimeUnit.MILLISECONDS).until(value(), equalTo(1));
     }
 
     @Test(timeout = 2000, expected = IllegalStateException.class)


### PR DESCRIPTION
* https://github.com/awaitility/awaitility/issues/102

As discussed in the mentioned issue, I introduced two new methods in the ConditionEvaluationListener, namely beforeEvaluation and onTimeout. Both methods are default interface methods, so that the ConditionEvaluationListener stays backward compatible. In addition to that I followed @johanhaleby suggestion of using tailor made data classes for the new methods, because EvaluatedCondition is not appropriate for the new use cases. 
