### PR TITLE
Fixes #148 condition timeout calculation units

### DIFF
--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -69,7 +69,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
         final Duration minWaitTime = conditionSettings.getMinWaitTime();
         final Duration holdPredicateWaitTime = conditionSettings.getHoldPredicateTime();
 
-        long pollingStartedNanos = System.nanoTime() - pollDelay.toMillis();
+        long pollingStartedNanos = System.nanoTime() - pollDelay.toNanos();
 
         int pollCount = 0;
         boolean succeededBeforeTimeout = false;

--- a/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
@@ -1,6 +1,8 @@
 
 package org.awaitility.core;
 
+import static org.awaitility.Awaitility.*;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -19,5 +21,14 @@ public class ConditionAwaiterTest {
         Duration duration = ConditionAwaiter.calculateConditionEvaluationDuration(Duration.ofNanos(10000000L), System.nanoTime());
 
         assertThat(duration.toNanos(), is(1L));
+    }
+
+    @Test public void atLeastIncludesPollDelayWithPollInterval() {
+        long start = System.currentTimeMillis();
+        await()
+            .pollDelay(Duration.ofMillis(100))
+            .pollInterval(Duration.ofMillis(50))
+            .atLeast(Duration.ofMillis(1000))
+            .until(() -> System.currentTimeMillis() - start > 1050);
     }
 }


### PR DESCRIPTION
When using a pollDuration and pollInterval, the condition timeout
was incorrectly coverting units.  Added test.