### PR TITLE
Broken link is fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you're using the Groovy DSL beaware that Groovy has been upgraded from 2.x to
 
 ## Links
 * [Change log](https://github.com/awaitility/awaitility/raw/master/changelog.txt)
-* Awaitility on [Ohloh](https://www.ohloh.net/p/awaitility)
+* Awaitility on [Open Hub](https://www.openhub.net/p/awaitility)
 * [Mailing list](http://groups.google.com/group/awaitility) for questions and support
 
 <a href="https://www.buymeacoffee.com/johanhaleby" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/arial-blue.png" alt="Buy Me A Coffee" style="height: 42px !important;width: 180px !important;" height="42px" width="180px"></a>


### PR DESCRIPTION
Just updated the link because the old link redirects to an obsolete website.