### PR TITLE
Avoid memory leak by caching only the original default uncaught exception handler globally

### DIFF
--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -36,8 +36,6 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
     private final AtomicReference<Throwable> uncaughtThrowable;
     private final ConditionSettings conditionSettings;
 
-    private final UncaughtExceptionHandler originalDefaultUncaughtExceptionHandler;
-
     /**
      * <p>Constructor for ConditionAwaiter.</p>
      *
@@ -52,7 +50,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
             throw new IllegalArgumentException("You must specify the condition settings (was null).");
         }
         // in order to solve https://github.com/awaitility/awaitility/issues/152 the original handler will be set back at the end
-        originalDefaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+        OriginalDefaultUncaughtExceptionHandler.set(Thread.getDefaultUncaughtExceptionHandler());
 
         if (conditionSettings.shouldCatchUncaughtExceptions()) {
             Thread.setDefaultUncaughtExceptionHandler(this);
@@ -173,7 +171,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
         } catch (Throwable e) {
             CheckedExceptionRethrower.safeRethrow(e);
         } finally {
-            Thread.setDefaultUncaughtExceptionHandler(originalDefaultUncaughtExceptionHandler);
+            Thread.setDefaultUncaughtExceptionHandler(OriginalDefaultUncaughtExceptionHandler.get());
             uncaughtThrowable.set(null);
             conditionSettings.getExecutorLifecycle().executeNormalCleanupBehavior(executor);
         }

--- a/awaitility/src/main/java/org/awaitility/core/OriginalDefaultUncaughtExceptionHandler.java
+++ b/awaitility/src/main/java/org/awaitility/core/OriginalDefaultUncaughtExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.awaitility.core;
+
+public class OriginalDefaultUncaughtExceptionHandler {
+
+    // null unless explicitly set
+    private static volatile Thread.UncaughtExceptionHandler originalDefaultUncaughtExceptionHandler;
+
+    public static Thread.UncaughtExceptionHandler get() {
+        return originalDefaultUncaughtExceptionHandler;
+    }
+
+    public static void set(Thread.UncaughtExceptionHandler eh) {
+        if (!(eh instanceof ConditionAwaiter)) {
+            originalDefaultUncaughtExceptionHandler = eh;
+        }
+    }
+}


### PR DESCRIPTION
Please check if it solves https://github.com/awaitility/awaitility/issues/182 