### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -152,7 +152,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>

--- a/awaitility-osgi-test/pom.xml
+++ b/awaitility-osgi-test/pom.xml
@@ -88,7 +88,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18</version>
 				<configuration>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
