### PR TITLE
More flexible way to enable logging

### DIFF
--- a/awaitility/src/main/java/org/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/org/awaitility/Awaitility.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -266,6 +267,7 @@ public class Awaitility {
      * <li>Catch all uncaught exceptions - true</li>
      * <li>Do not ignore caught exceptions</li>
      * <li>Don't handle condition evaluation results</li>
+     * <li>Don't log anything</li>
      * <li>No fail fast condition</li>
      * </ul>
      */
@@ -472,6 +474,39 @@ public class Awaitility {
      */
     public static void setDefaultConditionEvaluationListener(ConditionEvaluationListener defaultConditionEvaluationListener) {
         Awaitility.defaultConditionEvaluationListener = defaultConditionEvaluationListener;
+    }
+
+    /**
+     * Sets the default logging condition evaluation listener that all await statements will use. Method could override
+     * result of usage {@link #setDefaultConditionEvaluationListener(ConditionEvaluationListener)}.
+     *
+     * @param loggingListener logging condition evaluation each time evaluation of a condition occurs.
+     * @see #setDefaultConditionEvaluationListener(ConditionEvaluationListener)
+     */
+    public static void setLoggingListener(ConditionEvaluationListener loggingListener) {
+        Awaitility.defaultConditionEvaluationListener = loggingListener;
+    }
+
+    /**
+     * Sets the default logging condition evaluation listener that all await statements will use. Method could override
+     * result of usage {@link #setDefaultConditionEvaluationListener(ConditionEvaluationListener)} with custom consumer.
+     *
+     * @param logPrinter consumer for condition logging
+     * @see #setDefaultConditionEvaluationListener(ConditionEvaluationListener)
+     */
+    public static void setLogging(Consumer<String> logPrinter) {
+        setLoggingListener(new ConditionEvaluationLogger(logPrinter));
+    }
+
+    /**
+     * Sets the default logging condition evaluation listener that all await statements will use. Method could override
+     * result of usage {@link #setDefaultConditionEvaluationListener(ConditionEvaluationListener)} with logging to
+     * System.out.
+     *
+     * @see #setDefaultConditionEvaluationListener(ConditionEvaluationListener)
+     */
+    public static void setDefaultLogging() {
+        setLoggingListener(new ConditionEvaluationLogger(System.out::println));
     }
 
     /**

--- a/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -132,6 +133,26 @@ public class ConditionFactory {
     public ConditionFactory conditionEvaluationListener(ConditionEvaluationListener conditionEvaluationListener) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
                 exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+    }
+
+    /**
+     * Logging condition evaluation results each time evaluation of a condition occurs to System.out.
+     *
+     * @return the condition factory
+     */
+    public ConditionFactory logging() {
+        return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
+                exceptionsIgnorer, new ConditionEvaluationLogger(), executorLifecycle, failFastCondition);
+    }
+
+    /**
+     * Logging condition evaluation results each time evaluation of a condition occurs to chosen consumer.
+     *
+     * @return the condition factory
+     */
+    public ConditionFactory logging(Consumer<String> logPrinter) {
+        return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
+                exceptionsIgnorer, new ConditionEvaluationLogger(logPrinter), executorLifecycle, failFastCondition);
     }
 
     /**

--- a/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
@@ -16,9 +16,15 @@
 
 package org.awaitility.core;
 
+import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
@@ -27,6 +33,140 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class ConditionEvaluationLoggerTest {
+
+    private final PrintStream standardOut = System.out;
+
+    @After
+    @SuppressWarnings("unused")
+    public void resetDefaultSystemOut() {
+        System.setOut(standardOut);
+        Awaitility.reset();
+    }
+
+    /**
+     * Test should check that await.logging(Consumer) properly logging data to Consumer
+     */
+    @Test(timeout = 2000)
+    public void it_is_possible_to_use_logging_with_syntactic_sugar_via_condition_evaluation_logger_by_consumer() {
+        CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+
+        await().with()
+                .logging(logs::add)
+                .pollInterval(ONE_HUNDRED_MILLISECONDS)
+                .until(logs::size, is(4));
+
+        assertThat(
+                logs,
+                everyItem(
+                        anyOf(
+                                equalTo("Starting evaluation"),
+                                containsString("expected <4> but was"),
+                                containsString("reached its end value of <4>")
+                        )
+                )
+        );
+    }
+
+    /**
+     * Test should check that Awaitility.setLoggingListener(new ConditionEvaluationLogger(Consumer)) properly logging data to Consumer
+     */
+    @Test(timeout = 2000)
+    public void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_condition_evaluation_logger_by_consumer() {
+        CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+        Awaitility.setLoggingListener(new ConditionEvaluationLogger(logs::add));
+
+        await().with()
+                .pollInterval(ONE_HUNDRED_MILLISECONDS)
+                .until(logs::size, is(4));
+
+        assertThat(
+                logs,
+                everyItem(
+                        anyOf(
+                                equalTo("Starting evaluation"),
+                                containsString("expected <4> but was"),
+                                containsString("reached its end value of <4>")
+                        )
+                )
+        );
+    }
+
+    /**
+     * Test should check that Awaitility.setLogging(new ConditionEvaluationLogger(Consumer)) properly logging data to Consumer
+     */
+    @Test(timeout = 2000)
+    public void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_consumer() {
+        CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+        Awaitility.setLogging(logs::add);
+
+        await().with()
+                .pollInterval(ONE_HUNDRED_MILLISECONDS)
+                .until(logs::size, is(4));
+
+        assertThat(
+                logs,
+                everyItem(
+                        anyOf(
+                                equalTo("Starting evaluation"),
+                                containsString("expected <4> but was"),
+                                containsString("reached its end value of <4>")
+                        )
+                )
+        );
+    }
+
+    /**
+     * Test should check that await.logging() properly logging data to System.out
+     */
+    @Test(timeout = 2000)
+    public void it_is_possible_to_use_sout_logging_with_syntactic_sugar_via_condition_evaluation_logger() {
+        final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
+        final AtomicInteger stub = new AtomicInteger(0);
+
+        await().with()
+                .logging()
+                .pollInterval(ONE_HUNDRED_MILLISECONDS)
+                .until(stub::getAndIncrement, is(4));
+
+        assertThat(
+                Arrays.asList(outputStreamCaptor.toString().split("\n")),
+                everyItem(
+                        anyOf(
+                                equalTo("Starting evaluation\r"),
+                                containsString("expected <4> but was"),
+                                containsString("reached its end value of <4>")
+                        )
+                )
+        );
+    }
+
+    /**
+     * Test should check that Awaitility.setDefaultLogging() properly logging data to System.out
+     */
+    @Test(timeout = 2000)
+    public void it_is_possible_to_use_sout_logging_with_Awaitility_static_settings_via_condition_evaluation_logger() {
+        Awaitility.setDefaultLogging();
+
+        final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
+        final AtomicInteger stub = new AtomicInteger(0);
+
+        await().with()
+                .pollInterval(ONE_HUNDRED_MILLISECONDS)
+                .until(stub::getAndIncrement, is(4));
+
+        assertThat(
+                Arrays.asList(outputStreamCaptor.toString().split("\n")),
+                everyItem(
+                        anyOf(
+                                equalTo("Starting evaluation\r"),
+                                containsString("expected <4> but was"),
+                                containsString("reached its end value of <4>")
+                        )
+                )
+        );
+    }
 
     @Test(timeout = 2000)
     public void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_ctor_to_create_the_condition_evaluation_logger() {

--- a/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
@@ -130,10 +130,10 @@ public class ConditionEvaluationLoggerTest {
                 .until(stub::getAndIncrement, is(4));
 
         assertThat(
-                Arrays.asList(outputStreamCaptor.toString().split("\n")),
+                Arrays.asList(outputStreamCaptor.toString().replaceAll("\r", "").split("\n")),
                 everyItem(
                         anyOf(
-                                equalTo("Starting evaluation\r"),
+                                equalTo("Starting evaluation"),
                                 containsString("expected <4> but was"),
                                 containsString("reached its end value of <4>")
                         )
@@ -146,21 +146,21 @@ public class ConditionEvaluationLoggerTest {
      */
     @Test(timeout = 2000)
     public void it_is_possible_to_use_sout_logging_with_Awaitility_static_settings_via_condition_evaluation_logger() {
-        Awaitility.setDefaultLogging();
-
         final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStreamCaptor));
         final AtomicInteger stub = new AtomicInteger(0);
+
+        Awaitility.setDefaultLogging();
 
         await().with()
                 .pollInterval(ONE_HUNDRED_MILLISECONDS)
                 .until(stub::getAndIncrement, is(4));
 
         assertThat(
-                Arrays.asList(outputStreamCaptor.toString().split("\n")),
+                Arrays.asList(outputStreamCaptor.toString().replaceAll("\r", "").split("\n")),
                 everyItem(
                         anyOf(
-                                equalTo("Starting evaluation\r"),
+                                equalTo("Starting evaluation"),
                                 containsString("expected <4> but was"),
                                 containsString("reached its end value of <4>")
                         )


### PR DESCRIPTION
Hey there!

I'd like to add more flexible and simple way to add global logging for all conditions and logging for single condition.

Global Awaitility settings 
-----
from
```java 
Awaitility.setDefaultConditionEvaluationListener(new ConditionEvaluationLogger(log::info()));
```
To

```java
Awaitility.setLogging(log::info);
``` 
or for the `System.out`
```java
Awaitility.setDefaultLogging();
``` 


Single Condition settings 
-----
from
```java
await()
    .with()
    .conditionEvaluationListener(new ConditionEvaluationLogger(log::info))
    .pollInterval(ONE_HUNDRED_MILLISECONDS)
    .until(logs::size, is(4));
```

to

```java
await()
    .with()
    .logging(log::info)
    .pollInterval(ONE_HUNDRED_MILLISECONDS)
    .until(logs::size, is(4));
```

or for the `System.out`

```java
await()
    .with()
    .logging()
    .pollInterval(ONE_HUNDRED_MILLISECONDS)
    .until(logs::size, is(4));
```

TODO
-----
- [x] global Awaitility settings
- [x] single Condition settings
- [x] unit tests
- [x] java docs
- [ ] user docs