### PR TITLE
Add automatic module descriptor generation

### DIFF
--- a/awaitility/bnd.bnd
+++ b/awaitility/bnd.bnd
@@ -1,2 +1,5 @@
-Export-Package: \
-	org.awaitility.*
+Export-Package: org.awaitility.*
+# Use `maven-bundle-plugin` naming convention:
+Bundle-SymbolicName: org.awaitility
+# Add JPMS auto-generated module descriptor to JAR
+-jpms-module-info: $[Bundle-SymbolicName];access=0

--- a/awaitility/pom.xml
+++ b/awaitility/pom.xml
@@ -22,22 +22,15 @@
 
     <build>
         <plugins>
-            <!-- Warning: maven bundle plugin runs before shade so we need to hand tune the manifest -->
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
-                <configuration>
-                    <obrRepository>NONE</obrRepository>
-                    <instructions>
-                        <_include>-bnd.bnd</_include>
-                    </instructions>
-                </configuration>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
-                        <phase>process-classes</phase>
+                        <id>default-jar</id>
                         <goals>
-                            <goal>manifest</goal>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -48,17 +41,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default-jar</id>
-                        <configuration>
-                            <archive>
-                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                            </archive>
-                        </configuration>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                    <execution>
+                        <id>default-test-jar</id>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
         </developer>
     </developers>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false"
+         child.scm.developerConnection.inherit.append.path="false">
         <url>http://github.com/awaitility/awaitility/tree/${scm.branch}</url>
         <connection>scm:git:git://github.com/awaitility/awaitility.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/awaitility/awaitility.git</developerConnection>
@@ -75,6 +76,7 @@
     </prerequisites>
 
     <properties>
+        <bnd-maven-plugin.version>6.4.0</bnd-maven-plugin.version>
         <hamcrest.version>2.1</hamcrest.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -87,6 +89,8 @@
         <surefire.reportFormat>plain</surefire.reportFormat>
         <surefire.useFile>false</surefire.useFile>
         <surefire.version>3.0.0-M7</surefire.version>
+        <!-- For reproducible builds -->
+        <project.build.outputTimestamp>0</project.build.outputTimestamp>
     </properties>
 
     <modules>
@@ -99,6 +103,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${bnd-maven-plugin.version}</version>
+                </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>


### PR DESCRIPTION
At Log4j we use Awaitility extensively for all our asynchronous test needs, but our new 3.x will be JPMS-enabled and it cannot include libraries without even an `Automatic-Module-Name`.

This PR:
 * replaces `maven-bundle-plugin` with `bnd-maven-plugin`, whose release cycle follows more closely the BND engine,
 * configures BND to also generate a JPMS `module-info.class`.

After this upgrade, the OSGi descriptor looks like:
```
Bundle-Description                      A Java DSL for synchronizing asynchronous operations
Bundle-Developers                       "johan.haleby";name="Johan Haleby";organization=Parkster;organizationUrl="https://www.parkster.se";roles=Developer
Bundle-DocURL                           http://awaitility.org
Bundle-License                          "Apache 2.0";link="http://www.apache.org/licenses/LICENSE-2.0.txt"
Bundle-ManifestVersion                  2
Bundle-Name                             Awaitility
Bundle-SCM                              connection="scm:git:git://github.com/awaitility/awaitility.git"
                                        developer-connection="scm:git:ssh://git@github.com/awaitility/awaitility.git"
                                        tag=HEAD
                                        url="http://github.com/awaitility/awaitility/tree/master/awaitility"
Bundle-SymbolicName                     org.awaitility
Bundle-Version                          4.2.1.SNAPSHOT
Export-Package                          org.awaitility.classpath;version="4.2.1"
                                        org.awaitility.constraint;version="4.2.1"
                                        org.awaitility.core;uses:="org.awaitility.constraint,org.awaitility.pollinterval,org.hamcrest";version="4.2.1"
                                        org.awaitility.pollinterval;version="4.2.1"
                                        org.awaitility.reflect.exception;version="4.2.1"
                                        org.awaitility.reflect;uses:="org.awaitility.reflect.exception";version="4.2.1"
                                        org.awaitility.spi;version="4.2.1"
                                        org.awaitility;uses:="org.awaitility.core,org.awaitility.pollinterval,org.hamcrest";version="4.2.1"
Import-Package                          org.awaitility.classpath
                                        org.awaitility.constraint
                                        org.awaitility.core
                                        org.awaitility.pollinterval
                                        org.awaitility.reflect
                                        org.awaitility.reflect.exception
                                        org.awaitility.spi
                                        org.hamcrest.core;version="[2.1,3)"
                                        org.hamcrest;version="[2.1,3)"
Manifest-Version                        1.0
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```

The new JPMS `module-info.class` in the generated JAR file looks like:
```
module org.awaitility@4.2.1.SNAPSHOT {
  requires java.base;
  requires java.management;
  requires transitive org.hamcrest;
  exports org.awaitility;
  exports org.awaitility.classpath;
  exports org.awaitility.constraint;
  exports org.awaitility.core;
  exports org.awaitility.pollinterval;
  exports org.awaitility.reflect;
  exports org.awaitility.reflect.exception;
  exports org.awaitility.spi;
}
```

Closes #205.