### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -45,8 +45,8 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,6 +84,14 @@
                 <exclusion>
                     <groupId>org.apache.groovy</groupId>
                     <artifactId>groovy-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-engine</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/awaitility-groovy/src/test/groovy/org/awaitility/groovy/AwaitilityExtensionModuleGroovyTest.groovy
+++ b/awaitility-groovy/src/test/groovy/org/awaitility/groovy/AwaitilityExtensionModuleGroovyTest.groovy
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.awaitility.Awaitility.await
 import static org.hamcrest.Matchers.equalTo
-import static org.junit.Assert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
 
 class AwaitilityExtensionModuleGroovyTest extends Specification {
 

--- a/awaitility-groovy/src/test/groovy/org/awaitility/groovy/AwaitilityExtensionModuleTest.groovy
+++ b/awaitility-groovy/src/test/groovy/org/awaitility/groovy/AwaitilityExtensionModuleTest.groovy
@@ -17,32 +17,28 @@ package org.awaitility.groovy
 
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.groovy.classes.Asynch
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.Callable
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.awaitility.Awaitility.await
 import static org.hamcrest.Matchers.equalTo
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.jupiter.api.Assertions.assertThrows
 
 class AwaitilityExtensionModuleTest {
 
-  @Rule
-  public def ExpectedException exception = ExpectedException.none()
-
   @Test
-  def void groovyBooleanClosureSupport() {
+  void groovyBooleanClosureSupport() {
     def asynch = new Asynch().perform()
 
     await().until { asynch.getValue() == 1 }
   }
 
   @Test
-  def void groovyNonBooleanClosureSupport() {
+  void groovyNonBooleanClosureSupport() {
     int calls = 0
     // using "false" to detect a buggy implementation making use of toBoolean(): "false".toBoolean() returns false
     Closure<String> stringClosure = { ++calls > 1 ? "false" : null }
@@ -53,7 +49,7 @@ class AwaitilityExtensionModuleTest {
   }
 
   @Test
-  def void groovyRunnableSupport() {
+  void groovyRunnableSupport() {
     def asynch = new Asynch().perform()
 
     await().until(new Runnable() {
@@ -65,7 +61,7 @@ class AwaitilityExtensionModuleTest {
   }
 
   @Test
-  def void groovyBooleanCallableSupport() {
+  void groovyBooleanCallableSupport() {
     def asynch = new Asynch().perform()
 
     await().until(new Callable<Boolean>() {
@@ -77,37 +73,38 @@ class AwaitilityExtensionModuleTest {
   }
 
   @Test
-  def void timeoutMessagesDoesntContainAnonymousClassDetails() {
-    exception.expect ConditionTimeoutException
-    exception.expectMessage "Condition was not fulfilled within 500 milliseconds"
+  void timeoutMessagesDoesntContainAnonymousClassDetails() {
+    def message = "Condition was not fulfilled within 500 milliseconds."
 
     def asynch = new Asynch().perform()
 
-    await().atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+    ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+              () -> await().atMost(500, MILLISECONDS).until { asynch.getValue() == 2 })
+    assertEquals(message, ex.getMessage())
   }
 
   @Test
-  def void awaitWithAlias() {
-    exception.expect ConditionTimeoutException
-    exception.expectMessage "Condition with alias 'groovy' didn't complete within 500 milliseconds"
+  void awaitWithAlias() {
+    def message =  "Condition with alias 'groovy' didn't complete within 500 milliseconds because condition was not fulfilled."
 
     def asynch = new Asynch().perform()
 
-    await("groovy").atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+    ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+              () -> await("groovy").atMost(500, MILLISECONDS).until { asynch.getValue() == 2 })
+    assertEquals(message, ex.getMessage())
   }
 
   @Test
-  def void untilAssertedTest() {
+  void untilAssertedTest() {
     def asynch = new Asynch().perform()
 
     await("groovy").atMost(2000, MILLISECONDS).untilAsserted { assertEquals(1, asynch.getValue()) }
   }
 
   @Test
-  def void untilWithAssertionThrowsException() {
-    exception.expect AssertionError
-
+  void untilWithAssertionThrowsException() {
     def asynch = new Asynch().perform()
-    await("groovy").atMost(2000, MILLISECONDS).until { assertEquals(2, asynch.getValue()) }
+
+    assertThrows(AssertionError.class, () -> await("groovy").atMost(2000, MILLISECONDS).until { assertEquals(2, asynch.getValue()) })
   }
 }

--- a/awaitility-java8-test/pom.xml
+++ b/awaitility-java8-test/pom.xml
@@ -18,9 +18,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>awaitility-parent</artifactId>
         <groupId>org.awaitility</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <artifactId>awaitility-parent</artifactId>
+        <version>4.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>awaitility-java8-test</artifactId>
     <name>Awaitility tests for Java 8</name>
@@ -65,8 +65,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityCustomThreadMultipleWaitTest.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityCustomThreadMultipleWaitTest.java
@@ -15,8 +15,8 @@
  */
 package org.awaitility;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -32,14 +32,14 @@ import static org.awaitility.Awaitility.with;
 /**
  * Fixes issue <a href="https://github.com/awaitility/awaitility/issues/101">101</a>
  */
-public class AwaitilityCustomThreadMultipleWaitTest {
+class AwaitilityCustomThreadMultipleWaitTest {
 
-    @After public void
+    @AfterEach void
     reset_awaitility_after_each_test() {
         Awaitility.reset();
     }
 
-    @Test public void
+    @Test void
     custom_poll_thread_function_is_called_for_each_await_statement_when_using_static_configuration() {
         CopyOnWriteArrayList<Thread> threads = new CopyOnWriteArrayList<>();
 
@@ -67,7 +67,7 @@ public class AwaitilityCustomThreadMultipleWaitTest {
         assertThat(firstCalled).doesNotHaveValue(secondCalled.get());
 	}
 
-	@Test public void
+	@Test void
     custom_poll_thread_function_is_called_for_each_await_statement_when_using_instance_configuration() {
         CopyOnWriteArrayList<Thread> threads = new CopyOnWriteArrayList<>();
 
@@ -95,7 +95,7 @@ public class AwaitilityCustomThreadMultipleWaitTest {
         assertThat(firstCalled).doesNotHaveValue(secondCalled.get());
     }
 
-    @Test public void
+    @Test void
     custom_executor_service_is_not_shutdown_between_tests_when_using_static_configuration() throws ExecutionException, InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(3);
 
@@ -120,7 +120,7 @@ public class AwaitilityCustomThreadMultipleWaitTest {
         assertThat(firstCalled).hasValue(createdExecutorServiceThreadGroupName.get()).hasValue(secondCalled.get());
 	}
 	
-    @Test public void
+    @Test void
     custom_executor_service_is_not_shutdown_between_tests_when_using_instance_configuration() throws ExecutionException, InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 

--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityEvaluationConditionCancellationTest.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityEvaluationConditionCancellationTest.java
@@ -2,7 +2,7 @@ package org.awaitility;
 
 import org.awaitility.core.ConditionEvaluationLogger;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -15,9 +15,9 @@ import static org.hamcrest.Matchers.is;
 /**
  * Fixes <a href="https://github.com/awaitility/awaitility/issues/109">issue 109</a>.
  */
-public class AwaitilityEvaluationConditionCancellationTest {
+class AwaitilityEvaluationConditionCancellationTest {
 
-    @Test public void
+    @Test void
     doesnt_show_result_that_was_evaluated_after_timeout() {
         final Throwable throwable = catchThrowable(() -> {
             AtomicInteger ai = new AtomicInteger();

--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsJava8Test.java
@@ -21,10 +21,9 @@ import org.awaitility.classes.FakeRepository;
 import org.awaitility.classes.FakeRepositoryImpl;
 import org.awaitility.core.CheckedExceptionRethrower;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,21 +32,21 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.given;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityIgnoreExceptionsJava8Test {
+class AwaitilityIgnoreExceptionsJava8Test {
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksWithPredicates() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void exceptionIgnoringWorksWithPredicates() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreExceptionsMatching(e -> e.getMessage().endsWith("is not 1")).until(() -> {
             if (fakeRepository.getValue() != 1) {
@@ -57,8 +56,9 @@ public class AwaitilityIgnoreExceptionsJava8Test {
         });
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksWithPredicatesStatically() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void exceptionIgnoringWorksWithPredicatesStatically() {
         new Asynch(fakeRepository).perform();
         Awaitility.ignoreExceptionsByDefaultMatching(e -> e instanceof RuntimeException);
         await().atMost(1000, MILLISECONDS).until(() -> {
@@ -69,8 +69,9 @@ public class AwaitilityIgnoreExceptionsJava8Test {
         });
     }
 
-    @Test(timeout = 2000L)
-    public void untilAssertedCanIgnoreThrowable() throws Exception {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void untilAssertedCanIgnoreThrowable() throws Exception {
         new Asynch(fakeRepository).perform();
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -89,13 +90,16 @@ public class AwaitilityIgnoreExceptionsJava8Test {
      * the condition was fulfilled even though an exception is thrown later in the condition?
      * Or perhaps this behavior is correct?
      */
-    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
-    public void cannotHandleExceptionsThrownAfterAStatementIsFulfilled() throws Exception {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void cannotHandleExceptionsThrownAfterAStatementIsFulfilled() throws Exception {
         new Asynch(fakeRepository).perform();
 
-        given().ignoreExceptionsMatching(Objects::nonNull).await().atMost(800, MILLISECONDS).untilAsserted(() -> {
-            assertThat(fakeRepository.getValue()).isEqualTo(1);
-            CheckedExceptionRethrower.safeRethrow(new Throwable("Test"));
-        });
+        assertThrows(ConditionTimeoutException.class, () ->
+            given().ignoreExceptionsMatching(Objects::nonNull).await().atMost(800, MILLISECONDS).untilAsserted(() -> {
+                assertThat(fakeRepository.getValue()).isEqualTo(1);
+                CheckedExceptionRethrower.safeRethrow(new Throwable("Test"));
+            })
+        );
     }
 }

--- a/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/AwaitilityJava8Test.java
@@ -25,10 +25,10 @@ import org.awaitility.core.ConditionEvaluationLogger;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.ThrowingRunnable;
 import org.awaitility.support.CountDown;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.opentest4j.AssertionFailedError;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -39,7 +39,11 @@ import static org.awaitility.Awaitility.*;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Durations.TWO_SECONDS;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
 /**
  * Tests for await().until(Runnable) using AssertionCondition.
@@ -47,34 +51,34 @@ import static org.junit.Assert.*;
  * @author Marcin Zajączkowski, 2014-03-28
  * @author Johan Haleby
  */
-public class AwaitilityJava8Test {
+class AwaitilityJava8Test {
 
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void awaitAssertJAssertionAsLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitAssertJAssertionAsLambda() {
         new Asynch(fakeRepository).perform();
         await().untilAsserted(() -> Assertions.assertThat(fakeRepository.getValue()).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void awaitUsingLambdaVersionOfCallableBoolean() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitUsingLambdaVersionOfCallableBoolean() {
         new Asynch(fakeRepository).perform();
         await().until(() -> fakeRepository.getValue() == 1);
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void awaitAssertJAssertionAsAnonymousClass() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitAssertJAssertionAsAnonymousClass() {
         new Asynch(fakeRepository).perform();
         await().untilAsserted(new ThrowingRunnable() {
             @Override
@@ -84,97 +88,104 @@ public class AwaitilityJava8Test {
         });
     }
 
-    @Test(timeout = 2000)
-    public void awaitAssertJAssertionDisplaysOriginalErrorMessageAndTimeoutWhenConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(startsWith("Assertion condition defined as a lambda expression in " + AwaitilityJava8Test.class.getName()));
-        exception.expectMessage(endsWith("expected:<[1]> but was:<[0]> within 120 milliseconds."));
-
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitAssertJAssertionDisplaysOriginalErrorMessageAndTimeoutWhenConditionTimeoutExceptionOccurs() {
         new Asynch(fakeRepository).perform();
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).untilAsserted(
-                () -> Assertions.assertThat(fakeRepository.getValue()).isEqualTo(1));
+
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class, 
+                () -> with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).untilAsserted(
+                () -> Assertions.assertThat(fakeRepository.getValue()).isEqualTo(1))
+        );
+        assertThat(ex.getMessage()).startsWith("Assertion condition defined as a lambda expression in " + AwaitilityJava8Test.class.getName())
+                .endsWith("expected: 1\r\n but was: 0 within 120 milliseconds.");
     }
 
-    @Test(timeout = 2000)
-    public void awaitJUnitAssertionAsLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitJUnitAssertionAsLambda() {
         new Asynch(fakeRepository).perform();
         await().untilAsserted(() -> assertEquals(1, fakeRepository.getValue()));
     }
 
-    @Test(timeout = 2000)
-    public void awaitJUnitAssertionDisplaysOriginalErrorMessageAndTimeoutWhenConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(startsWith("Assertion condition defined as a lambda expression in " + AwaitilityJava8Test.class.getName()));
-        exception.expectMessage(endsWith("expected:<1> but was:<0> within 120 milliseconds."));
-
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).untilAsserted(
-                () -> assertEquals(1, fakeRepository.getValue()));
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitJUnitAssertionDisplaysOriginalErrorMessageAndTimeoutWhenConditionTimeoutExceptionOccurs() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).untilAsserted(
+                () -> assertEquals(1, fakeRepository.getValue()))
+        );
+        assertThat(ex.getMessage()).startsWith("Assertion condition defined as a lambda expression in " + AwaitilityJava8Test.class.getName())
+                .endsWith("expected: <1> but was: <0> within 120 milliseconds.");
     }
 
     /**
      * See <a href="https://github.com/awaitility/awaitility/issues/108">issue 108</a>
      */
-    @Test(timeout = 2000)
-    public void doesntRepeatAliasInLambdaConditionsForAssertConditions() {
-        try {
-            with().pollInterval(10, MILLISECONDS).then().await("my alias").atMost(120, MILLISECONDS).untilAsserted(
-                    () -> assertEquals(1, fakeRepository.getValue()));
-            fail("Should throw ConditionTimeoutException");
-        } catch (ConditionTimeoutException e) {
-            assertThat(countOfOccurrences(e.getMessage(), "my alias")).isEqualTo(1);
-        }
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void doesntRepeatAliasInLambdaConditionsForAssertConditions() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> with().pollInterval(10, MILLISECONDS).then().await("my alias").atMost(120, MILLISECONDS).untilAsserted(
+                () -> assertEquals(1, fakeRepository.getValue()))
+        );
+        assertThat(countOfOccurrences(ex.getMessage(), "my alias")).isEqualTo(1);
     }
 
     /**
      * See <a href="https://github.com/awaitility/awaitility/issues/108">issue 108</a>
      */
-    @Test(timeout = 2000)
-    public void doesntRepeatAliasInLambdaConditionsForCallableConditions() {
-        try {
-            with().pollInterval(10, MILLISECONDS).then().await("my alias").atMost(120, MILLISECONDS).until(() -> fakeRepository.getValue() == 1);
-            fail("Should throw ConditionTimeoutException");
-        } catch (ConditionTimeoutException e) {
-            assertThat(countOfOccurrences(e.getMessage(), "my alias")).isEqualTo(1);
-        }
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void doesntRepeatAliasInLambdaConditionsForCallableConditions() {
+         ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                 () -> with().pollInterval(10, MILLISECONDS).then().await("my alias").atMost(120, MILLISECONDS).until(() -> fakeRepository.getValue() == 1));
+         assertThat(countOfOccurrences(ex.getMessage(), "my alias")).isEqualTo(1);
     }
 
-    @Test(timeout = 2000)
-    public void lambdaErrorMessageLooksAlrightWhenUsingMethodReferences() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Lambda expression in org.awaitility.AwaitilityJava8Test that uses org.awaitility.classes.FakeRepository: expected <1> but was <0> within 120 milliseconds.");
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(fakeRepository::getValue, equalTo(1));
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void lambdaErrorMessageLooksAlrightWhenUsingMethodReferences() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(fakeRepository::getValue, equalTo(1))
+        );
+        assertThat(ex.getMessage()).isEqualTo("Lambda expression in org.awaitility.AwaitilityJava8Test that uses org.awaitility.classes.FakeRepository: expected <1> but was <0> within 120 milliseconds.");
     }
 
     @SuppressWarnings("Convert2MethodRef")
-    @Test(timeout = 2000)
-    public void lambdaErrorMessageLooksAlrightWhenUsingLambda() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Lambda expression in org.awaitility.AwaitilityJava8Test: expected <1> but was <0> within 120 milliseconds.");
-
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(() -> fakeRepository.getValue(), equalTo(1));
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void lambdaErrorMessageLooksAlrightWhenUsingLambda() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(() -> fakeRepository.getValue(), equalTo(1))
+        );
+        assertThat(ex.getMessage()).isEqualTo("Lambda expression in org.awaitility.AwaitilityJava8Test: expected <1> but was <0> within 120 milliseconds.");
     }
 
     @SuppressWarnings({"Convert2MethodRef", "CodeBlock2Expr"})
-    @Test(timeout = 2000)
-    public void lambdaErrorMessageLooksAlrightWhenUsingLambdaWithCurlyBraces() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Lambda expression in org.awaitility.AwaitilityJava8Test: expected <1> but was <0> within 120 milliseconds.");
-
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(() -> {
-            return fakeRepository.getValue();
-        }, equalTo(1));
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void lambdaErrorMessageLooksAlrightWhenUsingLambdaWithCurlyBraces() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(() -> {
+                    return fakeRepository.getValue();
+                }, equalTo(1))
+        );
+        assertThat(ex.getMessage()).isEqualTo("Lambda expression in org.awaitility.AwaitilityJava8Test: expected <1> but was <0> within 120 milliseconds.");
     }
 
-    @Test(timeout = 2000)
-    public void lambdaErrorMessageLooksAlrightWhenAwaitUsingLambdaVersionOfCallableBoolean() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Condition with lambda expression in org.awaitility.AwaitilityJava8Test was not fulfilled within 200 milliseconds.");
-
-        await().atMost(200, MILLISECONDS).until(() -> fakeRepository.getValue() == 2);
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void lambdaErrorMessageLooksAlrightWhenAwaitUsingLambdaVersionOfCallableBoolean() {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class,
+                () -> await().atMost(200, MILLISECONDS).until(() -> fakeRepository.getValue() == 2)
+        );
+        assertThat(ex.getMessage()).isEqualTo("Condition with lambda expression in org.awaitility.AwaitilityJava8Test was not fulfilled within 200 milliseconds.");
     }
 
-    @Test(timeout = 10000)
-    public void conditionResultsCanBeLoggedToSystemOut() {
+    @Timeout(value = 10000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void conditionResultsCanBeLoggedToSystemOut() {
         with()
                 .conditionEvaluationListener(condition -> System.out.printf("%s (elapsed time %dms, remaining time %dms)\n", condition.getDescription(), condition.getElapsedTimeInMS(), condition.getRemainingTimeInMS()))
                 .pollInterval(ONE_HUNDRED_MILLISECONDS)
@@ -182,8 +193,9 @@ public class AwaitilityJava8Test {
                 .until(new CountDown(5), anyOf(is(0), lessThan(0)));
     }
 
-    @Test(timeout = 10000)
-    public void loggingIntermediaryHandlerLogsToSystemOut() {
+    @Timeout(value = 10000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void loggingIntermediaryHandlerLogsToSystemOut() {
         with()
                 .conditionEvaluationListener(new ConditionEvaluationLogger(SECONDS))
                 .pollInterval(ONE_HUNDRED_MILLISECONDS)
@@ -191,44 +203,41 @@ public class AwaitilityJava8Test {
                 .until(new CountDown(5), is(equalTo(0)));
     }
 
-    @Test public void
+    @Test void
     canMakeUseOfThrowingMethodInAwaitilityToWrapRunnablesThatThrowsExceptions() {
         await().untilAsserted(() -> stringEquals("test", "test"));
     }
 
     @SuppressWarnings("ObviousNullCheck")
-    @Test(timeout = 2000L)
-    public void includesCauseInStackTrace()  {
-        try {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void includesCauseInStackTrace()  {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class, () ->
             await().atMost(200, MILLISECONDS).untilAsserted(() -> {
                 assertNotNull("34");
                 assertNotNull(null);
-            });
-            fail("Should throw ConditionTimeoutException");
-        } catch (ConditionTimeoutException e) {
-            assertThat(e.getCause().getClass().getName()).isEqualTo(AssertionError.class.getName());
-        }
+            })
+        );
+        assertThat(ex.getCause().getClass().getName()).isEqualTo(AssertionFailedError.class.getName());
     }
 
     // This was previously a bug (https://github.com/awaitility/awaitility/issues/78)
-    @Test(timeout = 2000L)
-    public void throwsExceptionImmediatelyWhenCallableConditionThrowsAssertionError() throws Exception {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void throwsExceptionImmediatelyWhenCallableConditionThrowsAssertionError() throws Exception {
         // Given
         long timeStart = System.nanoTime();
         new Asynch(fakeRepository).perform();
 
         // When
         final AtomicInteger counter = new AtomicInteger(0);
-        try {
-            await().atMost(1500, MILLISECONDS).until(() -> {
-                counter.incrementAndGet();
-                assertTrue(counter.get() >= 2);
-                return true;
-            });
-            fail("Expecting error");
-        } catch (AssertionError ignored) {
-            // expected
-        }
+        assertThrows(AssertionError.class,
+                () -> await().atMost(1500, MILLISECONDS).until(() -> {
+                    counter.incrementAndGet();
+                    assertTrue(counter.get() >= 2);
+                    return true;
+                })
+        );
 
         // Then
         long timeEnd = System.nanoTime();
@@ -237,10 +246,7 @@ public class AwaitilityJava8Test {
 
     // Asserts that https://github.com/awaitility/awaitility/issues/87 is resolved
     @Test
-    public void errorMessageLooksOkForHamcrestLambdaExpressionsWhoseMismatchDescriptionOriginallyIsEmptyStringByHamcrest() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(endsWith("expected a collection containing a string ending with \"hello\" but was <[]> within 50 milliseconds."));
-
+    void errorMessageLooksOkForHamcrestLambdaExpressionsWhoseMismatchDescriptionOriginallyIsEmptyStringByHamcrest() throws Exception {
         // Given
         FakeRepositoryList fakeRepositoryList = new FakeRepositoryList();
 
@@ -254,27 +260,28 @@ public class AwaitilityJava8Test {
         });
             
         // When
-        given().pollDelay(10, MILLISECONDS).await().atMost(50, MILLISECONDS).until(fakeRepositoryList::state, hasItem(endsWith("hello")));
-
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class, () ->
+                given().pollDelay(10, MILLISECONDS).await().atMost(50, MILLISECONDS).until(fakeRepositoryList::state, hasItem(endsWith("hello")))
+        );
+        assertThat(ex.getMessage()).endsWith("expected a collection containing a string ending with \"hello\" but was empty within 50 milliseconds.");
     }
 
     // Asserts that https://github.com/awaitility/awaitility/issues/97 is resolved
-    @Test(timeout = 2000L)
-    public void longConditionThrowsConditionTimeoutException() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Condition with org.awaitility.AwaitilityJava8Test was not fulfilled within 50 milliseconds.");
-
-        given().pollDelay(10, MILLISECONDS).await().atMost(50, MILLISECONDS).until(() -> {
-            Thread.sleep(1000);
-            return false;
-        });
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void longConditionThrowsConditionTimeoutException() throws Exception {
+        ConditionTimeoutException ex = assertThrows(ConditionTimeoutException.class, () ->
+                given().pollDelay(10, MILLISECONDS).await().atMost(50, MILLISECONDS).until(() -> {
+                    Thread.sleep(1000);
+                    return false;
+                })
+        );
+        assertThat(ex.getMessage()).isEqualTo("Condition with Lambda expression in org.awaitility.AwaitilityJava8Test was not fulfilled within 50 milliseconds.");
     }
 
     private void stringEquals(String first, String second) {
         Assertions.assertThat(first).isEqualTo(second);
     }
-
-
 
     private static int countOfOccurrences(String str, String subStr) {
         return (str.length() - str.replaceAll(Pattern.quote(subStr), "").length()) / subStr.length();

--- a/awaitility-java8-test/src/test/java/org/awaitility/ConditionEvaluationListenerJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/ConditionEvaluationListenerJava8Test.java
@@ -19,9 +19,9 @@ package org.awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.ThrowingRunnable;
 import org.awaitility.support.CountDown;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,16 +32,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.with;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class ConditionEvaluationListenerJava8Test {
+class ConditionEvaluationListenerJava8Test {
 
-    @Rule
-    public TestName testName = new TestName();
-
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForAssertionConditionsWhenUsingLambdasWithoutAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForAssertionConditionsWhenUsingLambdasWithoutAlias() {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
         with()
@@ -59,8 +58,9 @@ public class ConditionEvaluationListenerJava8Test {
         assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined as a lambda expression"), endsWith(expectedMatchMessage)));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForAssertionConditionsWhenUsingLambdasWithAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForAssertionConditionsWhenUsingLambdasWithAlias() {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
         with()
@@ -78,11 +78,12 @@ public class ConditionEvaluationListenerJava8Test {
         assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition with alias my alias defined as a lambda expression"), endsWith(expectedMatchMessage)));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForAssertionConditionsWhenUsingLambdasWithoutAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForAssertionConditionsWhenUsingLambdasWithoutAlias() {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
-        try {
+        assertThrows(ConditionTimeoutException.class, () -> 
             with()
                     .conditionEvaluationListener(condition -> {
                         try {
@@ -91,59 +92,57 @@ public class ConditionEvaluationListenerJava8Test {
                             throw new RuntimeException(e);
                         }
                         lastMatchMessage.set(condition.getDescription());
-                    }).await().atMost(150, MILLISECONDS).untilAsserted(() -> assertEquals(-1, (int) countDown.get()));
-            fail("Test should fail");
-        } catch (ConditionTimeoutException e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined as a lambda expression in"), containsString("expected:<-1> but was:<")));
-        }
+                    }).await().atMost(150, MILLISECONDS).untilAsserted(() -> assertEquals(-1, (int) countDown.get()))
+        );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined as a lambda expression in"), containsString("expected: <-1> but was: <")));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForAssertionConditionsWhenUsingLambdasWithAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForAssertionConditionsWhenUsingLambdasWithAlias() {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
-        try {
-            with().conditionEvaluationListener(condition -> {
+        assertThrows(ConditionTimeoutException.class, () ->
+                with().conditionEvaluationListener(condition -> {
                 try {
                     countDown.call();
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
                 lastMatchMessage.set(condition.getDescription());
-            }).await("my alias").atMost(150, MILLISECONDS).untilAsserted(() -> assertEquals(-1, (int) countDown.get()));
-            fail("Test should fail");
-        } catch (ConditionTimeoutException e) {
-            assertThat(lastMatchMessage.get(), startsWith("Assertion condition with alias my alias defined as a lambda expression"));
-        }
+            }).await("my alias").atMost(150, MILLISECONDS).untilAsserted(() -> assertEquals(-1, (int) countDown.get()))
+        );
+        assertThat(lastMatchMessage.get(), startsWith("Assertion condition with alias my alias defined as a lambda expression"));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForAssertionConditionsWhenNotUsingLambdasWithoutAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForAssertionConditionsWhenNotUsingLambdasWithoutAlias(TestInfo info) {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
-        with()
-                .conditionEvaluationListener(condition -> {
-                    try {
-                        countDown.call();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                    lastMatchMessage.set(condition.getDescription());
-                })
-                .untilAsserted(new ThrowingRunnable() {
-                    @Override
-                    public void run() {
-                        assertEquals(5, (int) countDown.get());
-                    }
-                });
+        with().conditionEvaluationListener(condition -> {
+            try {
+                countDown.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            lastMatchMessage.set(condition.getDescription());
+        })
+        .untilAsserted(new ThrowingRunnable() {
+            @Override
+            public void run() {
+                assertEquals(5, (int) countDown.get());
+            }
+        });
 
-        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined in"), containsString(testName.getMethodName()), endsWith("reached its end value")));
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined in"), containsString(info.getTestMethod().get().getName()), endsWith("reached its end value")));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForAssertionConditionsWhenNotUsingLambdasWithAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForAssertionConditionsWhenNotUsingLambdasWithAlias(TestInfo info) {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
         with()
@@ -162,15 +161,16 @@ public class ConditionEvaluationListenerJava8Test {
                     }
                 });
 
-        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition with alias my alias defined in"), containsString(testName.getMethodName()), endsWith("reached its end value")));
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition with alias my alias defined in"), containsString(info.getTestMethod().get().getName()), endsWith("reached its end value")));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForAssertionConditionsWhenNotUsingLambdasWithoutAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForAssertionConditionsWhenNotUsingLambdasWithoutAlias(TestInfo info) {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> {
                         lastMatchMessage.set(condition.getDescription());
@@ -184,19 +184,19 @@ public class ConditionEvaluationListenerJava8Test {
                 public void run() {
                     assertEquals(-1, (int) countDown.get());
                 }
-            });
-            fail("Expected to fail");
-        } catch (ConditionTimeoutException e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined in"), containsString(testName.getMethodName()), containsString("expected:")));
-        }
+            })
+        );
+
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition defined in"), containsString(info.getTestMethod().get().getName()), containsString("expected:")));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForAssertionConditionsWhenNotUsingLambdasWithAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForAssertionConditionsWhenNotUsingLambdasWithAlias(TestInfo info) {
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         CountDown countDown = new CountDown(10);
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> {
                         lastMatchMessage.set(condition.getDescription());
@@ -211,18 +211,17 @@ public class ConditionEvaluationListenerJava8Test {
                         public void run() {
                             assertEquals(5, (int) countDown.get());
                         }
-                    });
-            fail("Expected to fail");
-        } catch (ConditionTimeoutException e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition with alias my alias defined in"), containsString(testName.getMethodName()), containsString("expected:")));
-        }
+                    })
+        );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Assertion condition with alias my alias defined in"), containsString(info.getTestMethod().get().getName()), containsString("expected:")));
     }
 
     // Callable<Boolean> tests
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForCallableConditionsWithoutAliasWhenNotUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForCallableConditionsWithoutAliasWhenNotUsingLambda(TestInfo info) {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         with()
@@ -234,12 +233,13 @@ public class ConditionEvaluationListenerJava8Test {
                     }
                 });
 
-        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition defined in"), containsString(testName.getMethodName()), endsWith("returned true")));
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition defined in"), containsString(info.getTestMethod().get().getName()), endsWith("returned true")));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForCallableConditionsWithAliasWhenNotUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForCallableConditionsWithAliasWhenNotUsingLambda(TestInfo info) {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         with()
@@ -252,11 +252,12 @@ public class ConditionEvaluationListenerJava8Test {
                     }
                 });
 
-        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition with alias my alias defined in"), containsString(testName.getMethodName()), endsWith("returned true")));
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition with alias my alias defined in"), containsString(info.getTestMethod().get().getName()), endsWith("returned true")));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForCallableConditionsWithoutAliasWhenUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForCallableConditionsWithoutAliasWhenUsingLambda() {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         with()
@@ -266,8 +267,9 @@ public class ConditionEvaluationListenerJava8Test {
         assertThat(lastMatchMessage.get(), allOf(startsWith("Condition defined as a lambda expression in"), containsString(getClass().getName()), endsWith("returned true")));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMatchMessageForCallableConditionsWithAliasWhenUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMatchMessageForCallableConditionsWithAliasWhenUsingLambda() {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
         with()
@@ -281,11 +283,12 @@ public class ConditionEvaluationListenerJava8Test {
     // Callable<Boolean> mismatch tests
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForCallableConditionsWithoutAliasWhenNotUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForCallableConditionsWithoutAliasWhenNotUsingLambda(TestInfo info) {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> lastMatchMessage.set(condition.getDescription()))
                     .await().atMost(150, MILLISECONDS)
@@ -294,19 +297,18 @@ public class ConditionEvaluationListenerJava8Test {
                         public Boolean call() throws Exception {
                             return countDown.call() == -1;
                         }
-                    });
-            fail("Should fail");
-        } catch (Exception e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition defined in"), containsString(testName.getMethodName()), endsWith("returned false")));
-        }
+                    })
+        );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition defined in"), containsString(info.getTestMethod().get().getName()), endsWith("returned false")));
     }
 
     @SuppressWarnings("Convert2Lambda")
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForCallableConditionsWithAliasWhenNotUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForCallableConditionsWithAliasWhenNotUsingLambda(TestInfo info) {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> lastMatchMessage.set(condition.getDescription()))
                     .await("my alias").atMost(150, MILLISECONDS)
@@ -315,46 +317,43 @@ public class ConditionEvaluationListenerJava8Test {
                         public Boolean call() throws Exception {
                             return countDown.call() == 5;
                         }
-                    });
-            fail("Should fail");
-        } catch (Exception e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition with alias my alias defined in"), containsString(testName.getMethodName()), endsWith("returned false")));
-        }
+                    })
+        );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Callable condition with alias my alias defined in"), containsString(info.getTestMethod().get().getName()), endsWith("returned false")));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForCallableConditionsWithoutAliasWhenUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForCallableConditionsWithoutAliasWhenUsingLambda() {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> lastMatchMessage.set(condition.getDescription()))
                     .await().atMost(150, MILLISECONDS)
-                    .until(() -> countDown.call() == 5);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Condition defined as a lambda expression in"), containsString(getClass().getName()), endsWith("returned false")));
-        }
+                    .until(() -> countDown.call() == 5)
+            );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Condition defined as a lambda expression in"), containsString(getClass().getName()), endsWith("returned false")));
     }
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForCallableConditionsWithAliasWhenUsingLambda() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void expectedMismatchMessageForCallableConditionsWithAliasWhenUsingLambda() {
         final CountDown countDown = new CountDown(10);
         final AtomicReference<String> lastMatchMessage = new AtomicReference<>();
-        try {
+        assertThrows(ConditionTimeoutException.class, () ->
             with()
                     .conditionEvaluationListener(condition -> lastMatchMessage.set(condition.getDescription()))
                     .await("my alias").atMost(150, MILLISECONDS)
-                    .until(() -> countDown.call() == 5);
-            fail("Should fail");
-        } catch (Exception e) {
-            assertThat(lastMatchMessage.get(), allOf(startsWith("Condition with alias my alias defined as a lambda expression in "), containsString(getClass().getName()), endsWith("returned false")));
-        }
+                    .until(() -> countDown.call() == 5)
+        );
+        assertThat(lastMatchMessage.get(), allOf(startsWith("Condition with alias my alias defined as a lambda expression in "), containsString(getClass().getName()), endsWith("returned false")));
     }
 
     // Callable<Boolean> value test
-    @Test(timeout = 2000)
-    public void conditionOfCallableBooleanHasBooleanValuesInConditionEvalutionListener() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void conditionOfCallableBooleanHasBooleanValuesInConditionEvaluationListener() {
         final CountDown countDown = new CountDown(10);
         final List<Boolean> results = new ArrayList<>();
         with()

--- a/awaitility-java8-test/src/test/java/org/awaitility/IterativePollIntervalTest.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/IterativePollIntervalTest.java
@@ -17,7 +17,7 @@
 package org.awaitility;
 
 import org.awaitility.pollinterval.IterativePollInterval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -25,11 +25,11 @@ import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Durations.ONE_SECOND;
 import static org.awaitility.pollinterval.IterativePollInterval.iterative;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class IterativePollIntervalTest {
+class IterativePollIntervalTest {
 
-    @Test public void
+    @Test void
     iterative_poll_interval_allows_specifying_start_duration() {
         // Given
         IterativePollInterval pollInterval = new IterativePollInterval(prev -> prev.multipliedBy(2));
@@ -38,10 +38,10 @@ public class IterativePollIntervalTest {
         Duration duration = pollInterval.next(1, Duration.ZERO);
 
         // Then
-        assertThat(duration.toMillis(), is(2L));
+        assertThat(duration.toMillis(), is(0L));
     }
 
-    @Test public void
+    @Test void
     iterative_poll_interval_use_no_start_value_by_default() {
         // Given
         IterativePollInterval pollInterval = new IterativePollInterval(prev -> prev.multipliedBy(2));
@@ -53,7 +53,7 @@ public class IterativePollIntervalTest {
         assertThat(duration.toMillis(), is(2000L));
     }
 
-    @Test public void
+    @Test void
     iterative_poll_interval_allows_specifying_start_duration_through_dsl() {
         // Given
         IterativePollInterval pollInterval = iterative(prev -> prev.multipliedBy(2)).with().startDuration(FIVE_HUNDRED_MILLISECONDS);

--- a/awaitility-java8-test/src/test/java/org/awaitility/PollIntervalTest.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/PollIntervalTest.java
@@ -21,10 +21,9 @@ import org.awaitility.classes.FakeRepository;
 import org.awaitility.classes.FakeRepositoryImpl;
 import org.awaitility.core.ConditionEvaluationLogger;
 import org.awaitility.pollinterval.FibonacciPollInterval;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +34,7 @@ import static org.awaitility.core.ConditionEvaluationLogger.conditionEvaluationL
 import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static org.awaitility.pollinterval.FixedPollInterval.fixed;
 import static org.awaitility.pollinterval.IterativePollInterval.iterative;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
 /**
  * Tests for await().until(Runnable) using AssertionCondition.
@@ -42,51 +42,53 @@ import static org.awaitility.pollinterval.IterativePollInterval.iterative;
  * @author Marcin Zajączkowski, 2014-03-28
  * @author Johan Haleby
  */
-public class PollIntervalTest {
+class PollIntervalTest {
 
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void fibonacciPollInterval() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void fibonacciPollInterval() {
         new Asynch(fakeRepository).perform();
         await().with().conditionEvaluationListener(new ConditionEvaluationLogger()).pollInterval(new FibonacciPollInterval()).untilAsserted(() -> assertThat(fakeRepository.getValue()).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void fibonacciPollIntervalStaticallyImported() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void fibonacciPollIntervalStaticallyImported() {
         new Asynch(fakeRepository).perform();
         await().with().conditionEvaluationListener(conditionEvaluationLogger()).
                 pollInterval(fibonacci().with().offset(10).and().unit(MILLISECONDS)).
                 untilAsserted(() -> assertThat(fakeRepository.getValue()).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void inlinePollInterval() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void inlinePollInterval() {
         new Asynch(fakeRepository).perform();
         await().with().conditionEvaluationListener(new ConditionEvaluationLogger()).
                 pollInterval((__, previous) -> previous.multipliedBy(2).plusMillis(1)).
                 untilAsserted(() -> assertThat(fakeRepository.getValue()).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void iterativePollInterval() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void iterativePollInterval() {
         new Asynch(fakeRepository).perform();
         await().with().conditionEvaluationListener(new ConditionEvaluationLogger()).
                 pollInterval(iterative(duration -> duration.multipliedBy(2), FIVE_HUNDRED_MILLISECONDS)).
                 untilAsserted(() -> assertThat(fakeRepository.getValue()).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void fixedPollInterval() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void fixedPollInterval() {
         new Asynch(fakeRepository).perform();
         await().with().conditionEvaluationListener(new ConditionEvaluationLogger()).
                 pollInterval(fixed(TWO_HUNDRED_MILLISECONDS)).

--- a/awaitility-java8-test/src/test/java/org/awaitility/PollThreadJava8Test.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/PollThreadJava8Test.java
@@ -22,12 +22,13 @@ import org.awaitility.classes.FakeRepository;
 import org.awaitility.classes.FakeRepositoryImpl;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.InternalExecutorServiceFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runners.model.TestTimedOutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.platform.commons.JUnitException;
+import org.opentest4j.AssertionFailedError;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -40,22 +41,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.given;
 import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
 @SuppressWarnings("Duplicates")
-public class PollThreadJava8Test {
+class PollThreadJava8Test {
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionEvaluationsInTheSameThreadAsTheTestThread() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionEvaluationsInTheSameThreadAsTheTestThread() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> threadAtomicReference = new AtomicReference<>();
 
@@ -65,8 +68,9 @@ public class PollThreadJava8Test {
         assertThat(threadAtomicReference.get()).isEqualTo(Thread.currentThread());
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionEvaluationsInTheSameThreadAsTheTestThreadWhenConfiguredStatically() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionEvaluationsInTheSameThreadAsTheTestThreadWhenConfiguredStatically() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> threadAtomicReference = new AtomicReference<>();
 
@@ -78,23 +82,29 @@ public class PollThreadJava8Test {
         assertThat(threadAtomicReference.get()).isEqualTo(Thread.currentThread());
     }
 
-    @Test(timeout = 700)
-    public void uncaughtExceptionsArePropagatedToAwaitingThreadButCannotBreakForeverBlockWhenConditionIsEvaluatedFromTheTestThread() throws Exception {
-        exception.expect(TestTimedOutException.class);
+    @Test
+    void uncaughtExceptionsArePropagatedToAwaitingThreadButCannotBreakForeverBlockWhenConditionIsEvaluatedFromTheTestThread() throws Exception {
         new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-        given().catchUncaughtExceptions().and().pollInSameThread().await().forever().until(() -> fakeRepository.getValue() == 1);
+        AssertionFailedError error = assertThrows(AssertionFailedError.class,
+                () -> assertTimeoutPreemptively(Duration.ofMillis(700),
+                    () -> given().catchUncaughtExceptions().and().pollInSameThread().await().forever().until(() -> fakeRepository.getValue() == 1)
+            )
+        );
+        assertInstanceOf(JUnitException.class, error.getCause());
     }
 
-    @Test(timeout = 2000)
-    public void canTimeoutWhenPollingInSameThreadAsTest() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canTimeoutWhenPollingInSameThreadAsTest() throws Exception {
         new Asynch(fakeRepository).perform();
 
-        given().pollInSameThread().await().atMost(300, MILLISECONDS).until(() -> fakeRepository.getValue() == 1);
+        assertThrows(ConditionTimeoutException.class,
+                () -> given().pollInSameThread().await().atMost(300, MILLISECONDS).until(() -> fakeRepository.getValue() == 1));
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionEvaluationsCustomTestWithoutAliasThreadUsingJava8MethodReference() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionEvaluationsCustomTestWithoutAliasThreadUsingJava8MethodReference() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> threadAtomicReference = new AtomicReference<>();
 
@@ -104,8 +114,9 @@ public class PollThreadJava8Test {
         assertThat(threadAtomicReference.get()).isNotEqualTo(Thread.currentThread());
     }
 
-    @Test(timeout = 2000)
-    public void pollThreadSupplierIsCalledOncePerTest() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void pollThreadSupplierIsCalledOncePerTest() {
         new Asynch(fakeRepository).perform();
         List<Thread> conditionThreads = new CopyOnWriteArrayList<>();
 
@@ -115,8 +126,9 @@ public class PollThreadJava8Test {
         assertThat(new HashSet<>(conditionThreads)).doesNotContain(Thread.currentThread()).hasSize(1);
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionEvaluationsInCustomThread() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionEvaluationsInCustomThread() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> expectedThread = new AtomicReference<>();
         AtomicReference<Thread> actualThread = new AtomicReference<>();
@@ -131,8 +143,9 @@ public class PollThreadJava8Test {
         assertThat(actualThread.get()).isNotEqualTo(Thread.currentThread()).isEqualTo(expectedThread.get());
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionEvaluationsInCustomThreadWhenConfiguredStatically() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionEvaluationsInCustomThreadWhenConfiguredStatically() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> expectedThread = new AtomicReference<>();
         AtomicReference<Thread> actualThread = new AtomicReference<>();
@@ -149,8 +162,9 @@ public class PollThreadJava8Test {
         assertThat(actualThread.get()).isNotEqualTo(Thread.currentThread()).isEqualTo(expectedThread.get());
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionInSpecificExecutorService() throws ExecutionException, InterruptedException {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionInSpecificExecutorService() throws ExecutionException, InterruptedException {
         ExecutorService executorService = InternalExecutorServiceFactory.create(Thread::new);
         FakeRepository threadLocalRepo = executorService.submit(() -> new FakeRepository() {
             ThreadLocal<Integer> threadLocal = new ThreadLocal<>();
@@ -180,8 +194,9 @@ public class PollThreadJava8Test {
         given().pollExecutorService(executorService).await().atMost(1000, MILLISECONDS).until(() -> threadLocalRepo.getValue() == 1);
     }
 
-    @Test(timeout = 2000)
-    public void canRunConditionInSpecificExecutorServiceWhenExecutorServiceIsConfiguredStatically() throws ExecutionException, InterruptedException {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void canRunConditionInSpecificExecutorServiceWhenExecutorServiceIsConfiguredStatically() throws ExecutionException, InterruptedException {
 
         ExecutorService executorService = InternalExecutorServiceFactory.create(Thread::new);
         Awaitility.pollExecutorService(executorService);
@@ -213,8 +228,9 @@ public class PollThreadJava8Test {
         await().atMost(1000, MILLISECONDS).until(() -> threadLocalRepo.getValue() == 1);
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityPollThreadIsGivenANameEqualToAwaitilityThreadWhenNotUsingAnAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitilityPollThreadIsGivenANameEqualToAwaitilityThreadWhenNotUsingAnAlias() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> thread = new AtomicReference<>();
 
@@ -224,8 +240,9 @@ public class PollThreadJava8Test {
         assertThat(thread.get().getName()).isEqualTo("awaitility-thread");
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityPollThreadIsGivenANameIncludingAliasWhenUsingAnAlias() {
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
+    void awaitilityPollThreadIsGivenANameIncludingAliasWhenUsingAnAlias() {
         new Asynch(fakeRepository).perform();
         AtomicReference<Thread> thread = new AtomicReference<>();
 

--- a/awaitility-java8-test/src/test/java/org/awaitility/support/CountDown.java
+++ b/awaitility-java8-test/src/test/java/org/awaitility/support/CountDown.java
@@ -16,11 +16,8 @@
 
 package org.awaitility.support;
 
-import org.junit.Ignore;
-
 import java.util.concurrent.Callable;
 
-@Ignore("Not a test")
 public class CountDown implements Callable<Integer> {
 
     private int countDown;

--- a/awaitility-kotlin/pom.xml
+++ b/awaitility-kotlin/pom.xml
@@ -43,8 +43,8 @@
         </dependency>
         <!-- Test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/awaitility-kotlin/src/test/kotlin/org/awaitility/kotlin/KotlinTest.kt
+++ b/awaitility-kotlin/src/test/kotlin/org/awaitility/kotlin/KotlinTest.kt
@@ -27,11 +27,11 @@ import org.awaitility.core.ConditionEvaluationListener
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.pollinterval.FibonacciPollInterval.fibonacci
 import org.hamcrest.Matchers.*
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import java.lang.Thread.sleep
 import java.time.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -44,14 +44,10 @@ import kotlin.time.Duration.Companion.seconds
 
 class KotlinTest {
 
-    @Rule
-    @JvmField
-    val exception: ExpectedException = ExpectedException.none()
-
     private lateinit var asynch: Asynch
     private lateinit var fakeRepository: FakeRepository
 
-    @Before
+    @BeforeEach
     fun setup() {
         fakeRepository = FakeRepositoryImpl()
         asynch = Asynch(fakeRepository)
@@ -77,20 +73,20 @@ class KotlinTest {
 
     @Test
     fun assertionConditionFailsWithANiceErrorMessage() {
-        exception.expect(ConditionTimeoutException::class.java)
-        exception.expectMessage(startsWith("Assertion condition defined"))
-
         Asynch(fakeRepository).perform()
-        await().atMost(1, SECONDS).untilAsserted { assertEquals(2, fakeRepository.value) }
+        val exception = assertThrows(ConditionTimeoutException::class.java, {
+            await().atMost(1, SECONDS).untilAsserted { assertEquals(2, fakeRepository.value) }
+        })
+        assertThat(exception.message).startsWith("Assertion condition defined")
     }
 
     @Test
     fun booleanConditionFailsWithANiceErrorMessage() {
-        exception.expect(ConditionTimeoutException::class.java)
-        exception.expectMessage(allOf(startsWith("Condition"), endsWith("was not fulfilled within 1 seconds.")))
-
         Asynch(fakeRepository).perform()
-        await().atMost(1, SECONDS).until { fakeRepository.value == 2 }
+        val exception = assertThrows(ConditionTimeoutException::class.java, {
+            await().atMost(1, SECONDS).until { fakeRepository.value == 2 }
+        })
+        assertThat(exception.message).startsWith("Condition").endsWith("was not fulfilled within 1 seconds.")
     }
 
     @Test
@@ -243,7 +239,8 @@ class KotlinTest {
         assertThat(count).hasValueBetween(4, 6)
     }
 
-    @Test(timeout = 2000)
+    @Test
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     fun awaitDuringTimeOnCondition() {
         val duration = measureTimeMillis {
             await() during ONE_SECOND until { true }
@@ -252,7 +249,8 @@ class KotlinTest {
         assertThat(duration).isGreaterThan(1000)
     }
 
-    @Test(timeout = 2000)
+    @Test
+    @Timeout(value = 2000, unit = MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     fun awaitDuringTimeOnConditionWithKotlinDuration() {
         val duration = measureTimeMillis {
             await() during 1.seconds until { true }

--- a/awaitility-osgi-test/pom.xml
+++ b/awaitility-osgi-test/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <animal.sniffer.skip>true</animal.sniffer.skip>
         <pax-exam.version>4.13.4</pax-exam.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencies>
@@ -22,6 +23,12 @@
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-atinject_1.0_spec</artifactId>
             <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/awaitility-scala/pom.xml
+++ b/awaitility-scala/pom.xml
@@ -36,8 +36,8 @@
             <version>${scala.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>4.9.6</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/awaitility-scala/src/test/scala/org/awaitility/scala/AwaitilitySupportTest.scala
+++ b/awaitility-scala/src/test/scala/org/awaitility/scala/AwaitilitySupportTest.scala
@@ -20,14 +20,14 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import org.awaitility.Awaitility._
 import org.awaitility.core.ConditionTimeoutException
 import org.hamcrest.CoreMatchers.is
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.{containsString, endsWith, startsWith}
 import org.hamcrest.{CoreMatchers, Matchers}
-import org.junit.Assert._
-import org.junit._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api._
 
 import scala.language.postfixOps
 
-@Test
 class AwaitilitySupportTest extends AwaitilitySupport {
 
   @Test
@@ -40,9 +40,15 @@ class AwaitilitySupportTest extends AwaitilitySupport {
     await until isDone
   }
 
-  @Test(expected = classOf[ConditionTimeoutException])
+  @Test
   def timeout(): Unit = {
-    await atMost(500, MILLISECONDS) until { 2 == 1 }
+    try {
+      await atMost(500, MILLISECONDS) until { 2 == 1 }
+      fail("Expected timeout exception")
+    } catch {
+      case e : ConditionTimeoutException =>
+        assertEquals("Condition was not fulfilled within 500 milliseconds.", e getMessage)
+    }
   }
 
   @Test

--- a/awaitility/pom.xml
+++ b/awaitility/pom.xml
@@ -73,8 +73,8 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/awaitility/src/main/java/org/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/org/awaitility/Awaitility.java
@@ -82,14 +82,14 @@ import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
  * the following methods from the Awaitility framework:
  * <p>&nbsp;</p>
  * <ul>
- * <li>org.awaitility.Awaitlity.*</li>
+ * <li>org.awaitility.Awaitility.*</li>
  * <li>org.awaitility.Durations.*</li>
  * </ul>
  * It may also be useful to import these methods:
  * <ul>
  * <li>java.util.concurrent.TimeUnit.*</li>
  * <li>org.hamcrest.Matchers.*</li>
- * <li>org.junit.Assert.*</li>
+ * <li>org.junit.jupiter.api.Assertions.*</li>
  * </ul>
  * <p>&nbsp;</p>
  * A word on poll interval and poll delay: Awaitility starts to check the
@@ -219,7 +219,8 @@ public class Awaitility {
      * thread as the test. For safety you should always combine tests using this feature with a test framework specific timeout,
      * for example in JUnit:
      * <pre>
-     * @Test(timeout = 2000L)
+     *     @Timeout(value = 2000, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+    @Test
      * public void myTest() {
      *     Awaitility.pollInSameThread();
      *     await().forever().until(...);

--- a/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
@@ -576,8 +576,9 @@ public class ConditionFactory {
      * thread as the test. For safety you should always combine tests using this feature with a test framework specific timeout,
      * for example in JUnit:
      * <pre>
-     * @Test(timeout = 2000L)
-     * public void myTest() {
+     * @Timeout(value = 2000, unit = MILLISECONDS)
+     * @Test
+     * void myTest() {
      *     Awaitility.pollInSameThread();
      *     await().forever().until(...);
      * }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityAccumulatorTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityAccumulatorTest.java
@@ -16,19 +16,23 @@
 
 package org.awaitility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.concurrent.atomic.LongAccumulator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityAccumulatorTest {
+class AwaitilityAccumulatorTest {
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForLongAccumulators() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForLongAccumulators() {
         // Given
         LongAccumulator accumulator = new LongAccumulator((x, y) -> x * y * 2, 3);
 
@@ -47,8 +51,9 @@ public class AwaitilityAccumulatorTest {
         await().untilAccumulator(accumulator, equalTo(30L));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForLongAccumulatorsWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForLongAccumulatorsWithConsumerMatcher() {
         // Given
         LongAccumulator accumulator = new LongAccumulator((x, y) -> x * y * 2, 3);
 
@@ -67,8 +72,9 @@ public class AwaitilityAccumulatorTest {
         await().untilAccumulator(accumulator, value -> assertThat(value).isEqualTo(30L));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForDoubleAccumulators() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForDoubleAccumulators() {
         // Given
         DoubleAccumulator accumulator = new DoubleAccumulator((x, y) -> x * y * 2, 3.2d);
 
@@ -87,8 +93,9 @@ public class AwaitilityAccumulatorTest {
         await().untilAccumulator(accumulator, equalTo(35.2d));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForDoubleAccumulatorsWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForDoubleAccumulatorsWithConsumerMatcher() {
         // Given
         DoubleAccumulator accumulator = new DoubleAccumulator((x, y) -> x * y * 2, 3.2d);
 

--- a/awaitility/src/test/java/org/awaitility/AwaitilityAdderTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityAdderTest.java
@@ -16,19 +16,23 @@
 
 package org.awaitility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityAdderTest {
+class AwaitilityAdderTest {
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForLongAdders() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForLongAdders() {
         // Given
         LongAdder accumulator = new LongAdder();
 
@@ -47,8 +51,9 @@ public class AwaitilityAdderTest {
         await().untilAdder(accumulator, equalTo(5L));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForLongAddersWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForLongAddersWithConsumerMatcher() {
         // Given
         LongAdder accumulator = new LongAdder();
 
@@ -67,8 +72,9 @@ public class AwaitilityAdderTest {
         await().untilAdder(accumulator, value -> assertThat(value).isEqualTo(5L));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForDoubleAdders() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForDoubleAdders() {
         // Given
         DoubleAdder accumulator = new DoubleAdder();
 
@@ -87,8 +93,9 @@ public class AwaitilityAdderTest {
         await().untilAdder(accumulator, equalTo(5.5d));
     }
 
-    @Test(timeout = 2000)
-    public void awaitilityCanWaitForDoubleAddersWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitilityCanWaitForDoubleAddersWithConsumerMatcher() {
         // Given
         DoubleAdder accumulator = new DoubleAdder();
 

--- a/awaitility/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsTest.java
@@ -22,131 +22,148 @@ import org.awaitility.classes.FakeRepositoryImpl;
 import org.awaitility.classes.ThrowExceptionUnlessFakeRepositoryEqualsOne;
 import org.awaitility.core.ConditionEvaluationLogger;
 import org.awaitility.core.IgnoredException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityIgnoreExceptionsTest {
+class AwaitilityIgnoreExceptionsTest {
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach 
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreIgnoredUponRequest() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsDuringEvaluationAreIgnoredUponRequest() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreExceptions().until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void throwablesDuringEvaluationAreIgnoredUponRequest() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void throwablesDuringEvaluationAreIgnoredUponRequest() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreExceptions().until(conditionsThatIsThrowingAnExceptionForATime(AssertionError.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsOnlySpecifiedExceptionsAreIgnored() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsOnlySpecifiedExceptionsAreIgnored() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreException(IllegalArgumentException.class).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
-    
-    @Test(timeout = 2000)
-    public void ignoreExceptionWorksWithThrowable() {
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void ignoreExceptionWorksWithThrowable() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreException(AssertionError.class).until(conditionsThatIsThrowingAnExceptionForATime(AssertionError.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsOnlySpecifiedExceptionsAreIgnoredWhenUsingShortcut() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsOnlySpecifiedExceptionsAreIgnoredWhenUsingShortcut() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).and().ignoreExceptionsInstanceOf(RuntimeException.class).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreIgnoredWhenSetAsDefault() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsDuringEvaluationAreIgnoredWhenSetAsDefault() {
         new Asynch(fakeRepository).perform();
         Awaitility.ignoreExceptionsByDefault();
         await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
-    
-    @Test(timeout = 2000)
-    public void throwablesDuringEvaluationAreIgnoredWhenSetAsDefault() {
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void throwablesDuringEvaluationAreIgnoredWhenSetAsDefault() {
         new Asynch(fakeRepository).perform();
         Awaitility.ignoreExceptionsByDefault();
         await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime(AssertionError.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksForHamcrestMatchers() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionIgnoringWorksForHamcrestMatchers() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).with().ignoreExceptionsMatching(instanceOf(RuntimeException.class)).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void assertionErrorIgnoringWorksForHamcrestMatchers() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void assertionErrorIgnoringWorksForHamcrestMatchers() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).with().ignoreExceptionsMatching(instanceOf(AssertionError.class)).until(conditionsThatIsThrowingAnExceptionForATime(AssertionError.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksForHamcrestMatchersStatically() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionIgnoringWorksForHamcrestMatchersStatically() {
         new Asynch(fakeRepository).perform();
         Awaitility.ignoreExceptionsByDefaultMatching(instanceOf(RuntimeException.class));
         await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void noIgnoredExceptionsHavePrecedenceOverStaticallyDefinedExceptionIgnorer() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Repository value is not 1");
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void noIgnoredExceptionsHavePrecedenceOverStaticallyDefinedExceptionIgnorer() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
 
-        new Asynch(fakeRepository).perform();
-        Awaitility.ignoreExceptionsByDefaultMatching(instanceOf(RuntimeException.class));
-        await().atMost(1000, MILLISECONDS).with().ignoreNoExceptions().until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
+            new Asynch(fakeRepository).perform();
+            Awaitility.ignoreExceptionsByDefaultMatching(instanceOf(RuntimeException.class));
+            await().atMost(1000, MILLISECONDS).with().ignoreNoExceptions().until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
+        });
+        assertThat(exception.getMessage(), containsString("Repository value is not 1"));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksForPredicates() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionIgnoringWorksForPredicates() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).with().ignoreExceptionsMatching(RuntimeException.class::isInstance).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionIgnoringWorksForPredicatesStatically() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionIgnoringWorksForPredicatesStatically() {
         new Asynch(fakeRepository).perform();
         Awaitility.ignoreExceptionsByDefaultMatching(RuntimeException.class::isInstance);
         await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreReportedByDefault() {
-        exception.expect(RuntimeException.class);
-        exception.expectMessage(is("Repository value is not 1"));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsDuringEvaluationAreReportedByDefault() {
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
 
-        new Asynch(fakeRepository).perform();
-        await().atMost(1000, MILLISECONDS).with().until(conditionsThatIsThrowingAnExceptionForATime(RuntimeException.class));
+            new Asynch(fakeRepository).perform();
+            await().atMost(1000, MILLISECONDS).with().until(conditionsThatIsThrowingAnExceptionForATime(RuntimeException.class));
+        });
+        assertThat(exception.getMessage(), is("Repository value is not 1"));
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreIgnoredAndHandledUponRequest() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsDuringEvaluationAreIgnoredAndHandledUponRequest() {
         new Asynch(fakeRepository).perform();
 
         AtomicInteger exceptionCounter = new AtomicInteger(0);
@@ -167,24 +184,25 @@ public class AwaitilityIgnoreExceptionsTest {
 
     }
 
-    @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreNotHandledByDefault() {
-        exception.expect(RuntimeException.class);
-        exception.expectMessage(is("Repository value is not 1"));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsDuringEvaluationAreNotHandledByDefault() {
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
 
-        new Asynch(fakeRepository).perform();
+            new Asynch(fakeRepository).perform();
 
-        ConditionEvaluationLogger conditionEvaluationLogger = new ConditionEvaluationLogger() {
-            @Override
-            public void exceptionIgnored(IgnoredException ignoredException) {
-                fail("should not handle exception by default");
-            }
-        };
+            ConditionEvaluationLogger conditionEvaluationLogger = new ConditionEvaluationLogger() {
+                @Override public void exceptionIgnored(IgnoredException ignoredException) {
+                    fail("should not handle exception by default");
+                }
+            };
 
-        await().atMost(1000, MILLISECONDS).and()
-                .pollInterval(Duration.ofMillis(250))
-                .conditionEvaluationListener(conditionEvaluationLogger)
-                .until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
+            await().atMost(1000, MILLISECONDS).and()
+                    .pollInterval(Duration.ofMillis(250))
+                    .conditionEvaluationListener(conditionEvaluationLogger)
+                    .until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
+        });
+        assertThat(exception.getMessage(), is("Repository value is not 1"));
     }
 
     private Callable<Boolean> conditionsThatIsThrowingAnExceptionForATime(Class<? extends Throwable> throwable) {

--- a/awaitility/src/test/java/org/awaitility/AwaitilityReturnValuesTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityReturnValuesTest.java
@@ -18,34 +18,33 @@ package org.awaitility;
 import org.awaitility.classes.Asynch;
 import org.awaitility.classes.FakeRepository;
 import org.awaitility.classes.FakeRepositoryImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.fieldIn;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityReturnValuesTest {
+class AwaitilityReturnValuesTest {
 
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void returnsResultAfterSupplier() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void returnsResultAfterSupplier() throws Exception {
         new Asynch(fakeRepository).perform();
         int value = await().until(new Callable<Integer>() {
             public Integer call() throws Exception {
@@ -55,8 +54,9 @@ public class AwaitilityReturnValuesTest {
         assertEquals(1, value);
     }
 
-    @Test(timeout = 2000)
-    public void returnsResultAfterFieldInSupplier() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void returnsResultAfterFieldInSupplier() throws Exception {
         new Asynch(fakeRepository).perform();
         int value = await().until(fieldIn(fakeRepository).ofType(int.class).andWithName("value"), equalTo(1));
         assertEquals(1, value);

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -21,12 +21,11 @@ import org.awaitility.core.*;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.ComparisonFailure;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runners.model.TestTimedOutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.platform.commons.JUnitException;
+import org.opentest4j.AssertionFailedError;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -41,151 +40,167 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static java.util.concurrent.TimeUnit.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.*;
 import static org.awaitility.Durations.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class AwaitilityTest {
+class AwaitilityTest {
 
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationBlocksAutomatically() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationBlocksAutomatically() {
         new Asynch(fakeRepository).perform();
         await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationWithConsumerMatcher() {
         new Asynch(fakeRepository).perform();
         await().untilAsserted(fakeRepository::getValue, value -> Assertions.assertThat(value).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationSupportsSpecifyingPollIntervalUsingTimeunit() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsSpecifyingPollIntervalUsingTimeunit() {
         new Asynch(fakeRepository).perform();
         with().pollInterval(20, TimeUnit.MILLISECONDS).await().until(fakeRepositoryValueEqualsOne());
         given().pollInterval(20, TimeUnit.MILLISECONDS).await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationSupportsSpecifyingPollInterval() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsSpecifyingPollInterval() {
         new Asynch(fakeRepository).perform();
         with().pollInterval(ONE_HUNDRED_MILLISECONDS).then().await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationSupportsSpecifyingZeroAsPollDelay() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsSpecifyingZeroAsPollDelay() {
         new Asynch(fakeRepository).perform();
         with().pollDelay(Duration.ZERO).pollInterval(ONE_HUNDRED_MILLISECONDS).then().await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationSupportsSpecifyingZeroAsPollInterval() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsSpecifyingZeroAsPollInterval() {
         new Asynch(fakeRepository).perform();
         with().pollDelay(TWO_HUNDRED_MILLISECONDS).pollInterval(Duration.ZERO).then().await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationDoesntSupportSpecifyingForeverAsPollDelay() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Cannot delay polling forever");
-
-        new Asynch(fakeRepository).perform();
-        with().pollDelay(ForeverDuration.FOREVER).pollInterval(ONE_HUNDRED_MILLISECONDS).then().await().until(fakeRepositoryValueEqualsOne());
-        assertEquals(1, fakeRepository.getValue());
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationDoesntSupportSpecifyingForeverAsPollDelay() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            new Asynch(fakeRepository).perform();
+            with().pollDelay(ForeverDuration.FOREVER).pollInterval(ONE_HUNDRED_MILLISECONDS).then().await().until(fakeRepositoryValueEqualsOne());
+            assertEquals(1, fakeRepository.getValue());
+        });
+        assertThat(exception.getMessage(), containsString("Cannot delay polling forever"));
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationDoesntSupportSpecifyingForeverAsPollInterval() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Cannot use a fixed poll interval of length 'forever'");
-
-        new Asynch(fakeRepository).perform();
-        with().pollDelay(ONE_HUNDRED_MILLISECONDS).pollInterval(ForeverDuration.FOREVER).then().await().until(fakeRepositoryValueEqualsOne());
-        assertEquals(1, fakeRepository.getValue());
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationDoesntSupportSpecifyingForeverAsPollInterval() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+            new Asynch(fakeRepository).perform();
+            with().pollDelay(ONE_HUNDRED_MILLISECONDS).pollInterval(ForeverDuration.FOREVER).then().await().until(fakeRepositoryValueEqualsOne());
+            assertEquals(1, fakeRepository.getValue());
+        });
+        assertThat(exception.getMessage(), containsString("Cannot use a fixed poll interval of length 'forever'"));
     }
 
-    @Test(timeout = 2000)
-    public void awaitOperationSupportsSpecifyingPollDelay() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsSpecifyingPollDelay() {
         new Asynch(fakeRepository).perform();
         with().pollDelay(ONE_HUNDRED_MILLISECONDS).await().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
-    public void awaitOperationSupportsDefaultTimeout() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitOperationSupportsDefaultTimeout() {
         Awaitility.setDefaultTimeout(120, TimeUnit.MILLISECONDS);
-        await().until(value(), greaterThan(0));
-        assertEquals(1, fakeRepository.getValue());
+        assertThrows(ConditionTimeoutException.class, () -> await().until(value(), greaterThan(0)));
     }
 
-    @Test(timeout = 2000)
-    public void foreverConditionSpecificationUsingUntilWithDirectBlock() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void foreverConditionSpecificationUsingUntilWithDirectBlock() {
         new Asynch(fakeRepository).perform();
         await().forever().until(fakeRepositoryValueEqualsOne());
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void foreverConditionWithHamcrestMatchersWithDirectBlock() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void foreverConditionWithHamcrestMatchersWithDirectBlock() {
         new Asynch(fakeRepository).perform();
         await().forever().until(value(), equalTo(1));
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void foreverConditionWithHamcrestCollectionMatchersWithDirectBlock() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void foreverConditionWithHamcrestCollectionMatchersWithDirectBlock() {
         new Asynch(fakeRepository).perform();
         await().forever().until(valueAsList(), hasItem(1));
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 3000, expected = ConditionTimeoutException.class)
-    public void throwsTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void throwsTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
         new Asynch(fakeRepository).perform();
-        await().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(value(), equalTo(1));
+        assertThrows(ConditionTimeoutException.class, () -> await().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 3000)
-    public void doesNotThrowTimeoutExceptionWhenDoneLaterThanAtLeastConstraint() {
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void doesNotThrowTimeoutExceptionWhenDoneLaterThanAtLeastConstraint() {
         new Asynch(fakeRepository).perform();
         await().atLeast(100, NANOSECONDS).until(value(), equalTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void specifyingDefaultPollIntervalImpactsAllSubsequentUndefinedPollIntervalStatements() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void specifyingDefaultPollIntervalImpactsAllSubsequentUndefinedPollIntervalStatements() {
         Awaitility.setDefaultPollInterval(20, TimeUnit.MILLISECONDS);
         new Asynch(fakeRepository).perform();
         await().until(value(), equalTo(1));
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
-    public void conditionBreaksAfterDurationTimeout() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void conditionBreaksAfterDurationTimeout() {
         new Asynch(fakeRepository).perform();
-        await().atMost(200, TimeUnit.MILLISECONDS).until(value(), equalTo(1));
-        assertEquals(1, fakeRepository.getValue());
+        assertThrows(ConditionTimeoutException.class, () -> await().atMost(200, TimeUnit.MILLISECONDS).until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
-    public void remainingTimeIsNegativeOrZeroAfterDurationTimeouts() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void remainingTimeIsNegativeOrZeroAfterDurationTimeouts() {
         new Asynch(fakeRepository).perform();
         ConditionEvaluationListener<Integer> conditionEvaluationListener = new ConditionEvaluationListener<Integer>() {
             @Override
@@ -194,27 +209,30 @@ public class AwaitilityTest {
 
             @Override
             public void onTimeout(TimeoutEvent timeoutEvent) {
-                MatcherAssert.assertThat(timeoutEvent.getRemainingTimeInMS(), lessThanOrEqualTo(0L));
+                assertThat(timeoutEvent.getRemainingTimeInMS(), lessThanOrEqualTo(0L));
             }
         };
-        await().pollDelay(50, MILLISECONDS).conditionEvaluationListener(conditionEvaluationListener).atMost(100, TimeUnit.MILLISECONDS).until(value(), equalTo(1));
+        assertThrows(ConditionTimeoutException.class, () -> await().pollDelay(50, MILLISECONDS).conditionEvaluationListener(conditionEvaluationListener).atMost(100, TimeUnit.MILLISECONDS).until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = IllegalStateException.class)
-    public void uncaughtExceptionsArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenSetToCatchAllUncaughtExceptions() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void uncaughtExceptionsArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenSetToCatchAllUncaughtExceptions() {
         catchUncaughtExceptionsByDefault();
         new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-        await().forever().until(value(), equalTo(1));
+        assertThrows(IllegalStateException.class, () -> await().forever().until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = ComparisonFailure.class)
-    public void uncaughtThrowablesArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenSetToCatchAllUncaughtExceptions() {
-        new ExceptionThrowingAsynch(new ComparisonFailure("Message", "Something", "Something else")).perform();
-        await().forever().until(value(), equalTo(1));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void uncaughtThrowablesArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenSetToCatchAllUncaughtExceptions() {
+        new ExceptionThrowingAsynch(new AssertionFailedError("Message", "Something", "Something else")).perform();
+        assertThrows(AssertionFailedError.class, () -> await().forever().until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 2000)
-    public void uncaughtThrowablesFromOtherThreadsCanBeIgnored() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void uncaughtThrowablesFromOtherThreadsCanBeIgnored() throws Exception {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         final AtomicBoolean exceptionThrown = new AtomicBoolean(false);
         final ExecutorService es = Executors.newFixedThreadPool(5);
@@ -276,8 +294,9 @@ public class AwaitilityTest {
         }
     }
 
-    @Test(timeout = 2000)
-    public void ignoredExceptionsAreAddedToExceptionHierarchy() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void ignoredExceptionsAreAddedToExceptionHierarchy() {
         try {
             await().ignoreExceptions().atMost(200, TimeUnit.MILLISECONDS).until(new Callable<Boolean>() {
                 @Override
@@ -292,169 +311,179 @@ public class AwaitilityTest {
         }
     }
 
-    @Test(timeout = 2000, expected = IllegalStateException.class)
-    public void uncaughtExceptionsArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenCatchingAllUncaughtExceptions() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void uncaughtExceptionsArePropagatedToAwaitingThreadAndBreaksForeverBlockWhenCatchingAllUncaughtExceptions() {
         new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-        catchUncaughtExceptions().and().await().forever().until(value(), equalTo(1));
+        assertThrows(IllegalStateException.class, () -> catchUncaughtExceptions().and().await().forever().until(value(), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
-    public void whenDontCatchUncaughtExceptionsIsSpecifiedThenExceptionsFromOtherThreadsAreNotCaught() throws Exception {
-        new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
-            @Override
-            public void testLogic() {
-                new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-                dontCatchUncaughtExceptions().and().await().atMost(ONE_SECOND).until(value(), equalTo(1));
-            }
-        };
-    }
-
-    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
-    public void whenDontCatchUncaughtExceptionsIsSpecifiedAndTheBuildOfTheAwaitStatementHasStartedThenExceptionsFromOtherThreadsAreNotCaught()
-            throws Exception {
-        new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
-            @Override
-            public void testLogic() {
-                new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-                await().and().dontCatchUncaughtExceptions().given().timeout(ONE_SECOND).until(value(), equalTo(1));
-            }
-        };
-    }
-
-    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
-    public void catchUncaughtExceptionsIsReset() throws Exception {
-        new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
-            @Override
-            public void testLogic() {
-                new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
-                dontCatchUncaughtExceptions().and().await().atMost(ONE_SECOND).until(value(), equalTo(1));
-            }
-        };
-    }
-
-    @Test(timeout = 2000, expected = IllegalStateException.class)
-    public void exceptionsInConditionsArePropagatedToAwaitingThreadAndBreaksForeverBlock() {
-        final ExceptionThrowingFakeRepository repository = new ExceptionThrowingFakeRepository();
-        new Asynch(repository).perform();
-        await().until(new FakeRepositoryValue(repository), equalTo(1));
-    }
-
-    @Test(timeout = 2000)
-    public void awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionOccurs() {
-        String alias = "test";
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(
-                "Condition with alias 'test' didn't complete within 120 milliseconds because org.awaitility.classes.FakeRepositoryValue expected a value greater than <0> but <0> was equal to <0>.");
-
-        await(alias).atMost(120, MILLISECONDS).until(value(), greaterThan(0));
-    }
-
-    @Test(timeout = 2000)
-    public void awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionAndConditionIsACallableOccurs() {
-        String alias = "test";
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Condition with alias 'test' didn't complete within 120 milliseconds because condition returned by method \"awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionAndConditionIsACallableOccurs\" in class org.awaitility.AwaitilityTest was not fulfilled.");
-
-        //noinspection Convert2Lambda - This is because we want to try a real Callable at least once in the test suite
-        await(alias).atMost(120, MILLISECONDS).until(new Callable<Boolean>() {
-            public Boolean call() {
-                return fakeRepository.getValue() > 0;
-            }
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void whenDontCatchUncaughtExceptionsIsSpecifiedThenExceptionsFromOtherThreadsAreNotCaught() throws Exception {
+        assertThrows(ConditionTimeoutException.class, () -> {
+            new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
+                @Override public void testLogic() {
+                    new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
+                    dontCatchUncaughtExceptions().and().await().atMost(ONE_SECOND).until(value(), equalTo(1));
+                }
+            };
         });
     }
 
-    @Test(timeout = 2000)
-    public void awaitDisplaysSupplierAndMatcherMismatchMessageWhenConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(FakeRepositoryValue.class.getName()
-                + " expected a value greater than <0> but <0> was equal to <0> within 120 milliseconds.");
-
-        with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(value(), greaterThan(0));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void whenDontCatchUncaughtExceptionsIsSpecifiedAndTheBuildOfTheAwaitStatementHasStartedThenExceptionsFromOtherThreadsAreNotCaught()
+            throws Exception {
+        assertThrows(ConditionTimeoutException.class, () -> {
+            new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
+                @Override public void testLogic() {
+                    new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
+                    await().and().dontCatchUncaughtExceptions().given().timeout(ONE_SECOND).until(value(), equalTo(1));
+                }
+            };
+        });
     }
 
-    @Test(timeout = 2000)
-    public void awaitDisplaysCallableNameWhenConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(String.format("Condition %s was not fulfilled within 120 milliseconds.",
-                FakeRepositoryEqualsOne.class.getName()));
-
-        await().atMost(120, MILLISECONDS).until(fakeRepositoryValueEqualsOne());
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void catchUncaughtExceptionsIsReset() throws Exception {
+        assertThrows(ConditionTimeoutException.class, () -> {
+            new AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest() {
+                @Override public void testLogic() {
+                    new ExceptionThrowingAsynch(new IllegalStateException("Illegal state!")).perform();
+                    dontCatchUncaughtExceptions().and().await().atMost(ONE_SECOND).until(value(), equalTo(1));
+                }
+            };
+        });
     }
 
-    @Test(timeout = 2000)
-    public void awaitDisplaysMethodDeclaringTheCallableWhenCallableIsAnonymousClassAndConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception
-                .expectMessage(String
-                        .format("Condition returned by method \"fakeRepositoryValueEqualsOneAsAnonymous\" in class %s was not fulfilled within 120 milliseconds.",
-                                AwaitilityTest.class.getName()));
-
-        await().atMost(120, MILLISECONDS).until(fakeRepositoryValueEqualsOneAsAnonymous());
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void exceptionsInConditionsArePropagatedToAwaitingThreadAndBreaksForeverBlock() {
+        final ExceptionThrowingFakeRepository repository = new ExceptionThrowingFakeRepository();
+        new Asynch(repository).perform();
+        assertThrows(IllegalStateException.class, () -> await().until(new FakeRepositoryValue(repository), equalTo(1)));
     }
 
-    @Test(timeout = 2000)
-    public void awaitDisplaysMethodDeclaringTheSupplierWhenSupplierIsAnonymousClassAndConditionTimeoutExceptionOccurs() {
-        exception.expect(ConditionTimeoutException.class);
-        exception
-                .expectMessage(String
-                        .format("%s.valueAsAnonymous Callable expected %s but was <0> within 120 milliseconds.",
-                                AwaitilityTest.class.getName(), equalTo(2).toString()));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionOccurs() {
+        String alias = "test";
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            await(alias).atMost(120, MILLISECONDS).until(value(), greaterThan(0)));
+        assertThat(exception.getMessage(), containsString("Condition with alias 'test' didn't complete within 120 milliseconds because org.awaitility.classes.FakeRepositoryValue expected a value greater than <0> but <0> was equal to <0>."));
+    }
 
-        with().pollInterval(10, MILLISECONDS).await().atMost(120, MILLISECONDS).until(valueAsAnonymous(), equalTo(2));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionAndConditionIsACallableOccurs() {
+        String alias = "test";
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            //noinspection Convert2Lambda - This is because we want to try a real Callable at least once in the test suite
+            await(alias).atMost(120, MILLISECONDS).until(new Callable<Boolean>() {
+                public Boolean call() {
+                    return fakeRepository.getValue() > 0;
+                }
+            }));
+        assertThat(exception.getMessage(), matchesPattern("Condition with alias 'test' didn't complete within 120 milliseconds because condition returned by method \\\"lambda\\$awaitWithAliasDisplaysAliasWhenConditionTimeoutExceptionAndConditionIsACallableOccurs\\$\\d+\\\" in class org.awaitility.AwaitilityTest was not fulfilled."));
+    }
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDisplaysSupplierAndMatcherMismatchMessageWhenConditionTimeoutExceptionOccurs() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            with().pollInterval(10, MILLISECONDS).then().await().atMost(120, MILLISECONDS).until(value(), greaterThan(0)));
+        assertThat(exception.getMessage(), containsString(FakeRepositoryValue.class.getName()
+                + " expected a value greater than <0> but <0> was equal to <0> within 120 milliseconds."));
+    }
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDisplaysCallableNameWhenConditionTimeoutExceptionOccurs() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            await().atMost(120, MILLISECONDS).until(fakeRepositoryValueEqualsOne()));
+        assertThat(exception.getMessage(), containsString(String.format("Condition %s was not fulfilled within 120 milliseconds.",
+                FakeRepositoryEqualsOne.class.getName())));
+    }
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDisplaysMethodDeclaringTheCallableWhenCallableIsAnonymousClassAndConditionTimeoutExceptionOccurs() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            await().atMost(120, MILLISECONDS).until(fakeRepositoryValueEqualsOneAsAnonymous()));
+        assertThat(exception.getMessage(), containsString(String
+                .format("Condition returned by method \"fakeRepositoryValueEqualsOneAsAnonymous\" in class %s was not fulfilled within 120 milliseconds.",
+                        AwaitilityTest.class.getName())));
+    }
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDisplaysMethodDeclaringTheSupplierWhenSupplierIsAnonymousClassAndConditionTimeoutExceptionOccurs() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            with().pollInterval(10, MILLISECONDS).await().atMost(120, MILLISECONDS).until(valueAsAnonymous(), equalTo(2)));
+        assertThat(exception.getMessage(), containsString(String
+                .format("%s.valueAsAnonymous Callable expected %s but was <0> within 120 milliseconds.",
+                        AwaitilityTest.class.getName(), equalTo(2).toString())));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(timeout = 2000)
-    public void awaitDisplaysMethodDeclaringTheSupplierWhenSupplierIsAnonymousClassAndConditionTimeoutExceptionOccursWhenUsingNanos() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(Matchers.anyOf(Stream.of(equalTo(0).toString(), "null")
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDisplaysMethodDeclaringTheSupplierWhenSupplierIsAnonymousClassAndConditionTimeoutExceptionOccursWhenUsingNanos() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () ->
+            with().pollInterval(10, NANOSECONDS).await().atMost(120, NANOSECONDS).until(valueAsAnonymous(), equalTo(2)));
+        assertThat(exception.getMessage(), Matchers.anyOf(Stream.of(equalTo(0).toString(), "null")
                 .map(s -> String.format("%s.valueAsAnonymous Callable expected %s but was %s within 120 nanoseconds.", AwaitilityTest.class.getName(), equalTo(2).toString(), s))
                 .map(Matchers::containsString)
                 .toArray(Matcher[]::new)));
-
-        with().pollInterval(10, NANOSECONDS).await().atMost(120, NANOSECONDS).until(valueAsAnonymous(), equalTo(2));
-    }
-
-    @Test(timeout = 500)
-    public void noArithmeticExceptionIsThrownWhenConvertingASaneAmountOfDaysToNanos() {
-        exception.expect(TestTimedOutException.class); // We don't actually want to wait for 10 days, just that we don't get an ArithmeticException when converting days to nanos
-        with().pollInterval(10, DAYS).await().atMost(120, DAYS).until(valueAsAnonymous(), equalTo(2));
-    }
-
-    @Test(timeout = 2000)
-    public void throwsNiceExceptionWhenPollDurationIsSpecifiedAsNanosAndIsLessThanPollInterval() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Timeout (122 nanoseconds) must be greater than the poll delay (10 milliseconds).");
-
-        with().pollInterval(10, MILLISECONDS).await().atMost(122, NANOSECONDS).until(valueAsAnonymous(), equalTo(2));
     }
 
     @Test
-    public void awaitilityThrowsIllegalArgumentExceptionWhenTimeoutIsLessThanPollDelay() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(is("Timeout (10 seconds) must be greater than the poll delay (10 minutes)."));
-
-        with().pollDelay(10, MINUTES).await().atMost(10, SECONDS).until(fakeRepositoryValueEqualsOne());
+    void noArithmeticExceptionIsThrownWhenConvertingASaneAmountOfDaysToNanos() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> // We don't actually want to wait for 10 days, just that we don't get an ArithmeticException when converting days to nanos
+            assertTimeoutPreemptively(Duration.ofMillis(500),
+                    () -> with().pollInterval(10, DAYS).await().atMost(120, DAYS).until(valueAsAnonymous(), equalTo(2))
+            )
+        );
+        assertInstanceOf(JUnitException.class, error.getCause());
     }
 
     @Test
-    public void awaitilityThrowsIllegalArgumentExceptionWhenTimeoutIsEqualToPollDelay() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(is("Timeout (200 milliseconds) must be greater than the poll delay (200 milliseconds)."));
-
-        with().with().pollDelay(20, MILLISECONDS).pollDelay(200, MILLISECONDS).await().atMost(200, MILLISECONDS).until(fakeRepositoryValueEqualsOne());
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void throwsNiceExceptionWhenPollDurationIsSpecifiedAsNanosAndIsLessThanPollInterval() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+            with().pollInterval(10, MILLISECONDS).await().atMost(122, NANOSECONDS).until(valueAsAnonymous(), equalTo(2)));
+        assertThat(exception.getMessage(), containsString("Timeout (122 nanoseconds) must be greater than the poll delay (10 milliseconds)."));
     }
 
-    @Test(timeout = 2000L, expected = IllegalStateException.class)
-    public void rethrowsExceptionsInCallable() {
-        await().atMost(1, TimeUnit.SECONDS)
-                .until(() -> {
-                    throw new IllegalStateException("Hello");
-                });
+    @Test
+    void awaitilityThrowsIllegalArgumentExceptionWhenTimeoutIsLessThanPollDelay() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+            with().pollDelay(10, MINUTES).await().atMost(10, SECONDS).until(fakeRepositoryValueEqualsOne()));
+        assertThat(exception.getMessage(), is("Timeout (10 seconds) must be greater than the poll delay (10 minutes)."));
     }
 
-    @Test(timeout = 2000L)
-    public void awaitDuringTimeOnCondition() throws Exception {
+    @Test
+    void awaitilityThrowsIllegalArgumentExceptionWhenTimeoutIsEqualToPollDelay() {
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+            with().with().pollDelay(20, MILLISECONDS).pollDelay(200, MILLISECONDS).await().atMost(200, MILLISECONDS).until(fakeRepositoryValueEqualsOne()));
+        assertThat(exception.getMessage(), is("Timeout (200 milliseconds) must be greater than the poll delay (200 milliseconds)."));
+    }
+
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void rethrowsExceptionsInCallable() {
+        assertThrows(IllegalStateException.class, () ->
+            await().atMost(1, TimeUnit.SECONDS)
+                    .until(() -> {
+                        throw new IllegalStateException("Hello");
+                    }));
+    }
+
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDuringTimeOnCondition() throws Exception {
         Duration duration = measureDuration(() ->
             await()
                 .during(1, SECONDS)
@@ -464,8 +493,9 @@ public class AwaitilityTest {
         assertThat(duration.toMillis(), greaterThan(1000L));
     }
 
-    @Test(timeout = 2500L)
-    public void awaitDuringTimeWillWaitTheTimeStartingWhenTheConditionHolds() throws Exception {
+    @Test
+    @Timeout(value = 2500L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDuringTimeWillWaitTheTimeStartingWhenTheConditionHolds() throws Exception {
         long startTime = System.currentTimeMillis();
 
         Duration duration = measureDuration(() ->
@@ -479,26 +509,31 @@ public class AwaitilityTest {
         assertThat(duration.toMillis(), greaterThan(1500L));
     }
 
-    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
-    public void awaitDuringTimeWillThrowExceptionWhenTimeOut() {
-        await()
-            .atMost(1000, MILLISECONDS)
-            .during(200, MILLISECONDS)
-            .until(() -> false);
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDuringTimeWillThrowExceptionWhenTimeOut() {
+        assertThrows(ConditionTimeoutException.class, () ->
+            await()
+                    .atMost(1000, MILLISECONDS)
+                    .during(200, MILLISECONDS)
+                    .until(() -> false));
     }
 
-    @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
-    public void awaitDuringTimeWillThrowExceptionWhenTimeOutEvenIfConditionIsOkAtTheEndButNotDuringPeriod() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDuringTimeWillThrowExceptionWhenTimeOutEvenIfConditionIsOkAtTheEndButNotDuringPeriod() {
         long startTime = System.currentTimeMillis();
 
-        await()
-            .atMost(1500, MILLISECONDS)
-            .during(1000, MILLISECONDS)
-            .until(() -> (System.currentTimeMillis() - startTime) > 1000L);
+        assertThrows(ConditionTimeoutException.class, () ->
+            await()
+                    .atMost(1500, MILLISECONDS)
+                    .during(1000, MILLISECONDS)
+                    .until(() -> (System.currentTimeMillis() - startTime) > 1000L));
     }
 
-    @Test(timeout = 2000L)
-    public void awaitDuringTimeOnConditionMessingAtLeastAtMost() throws Exception {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitDuringTimeOnConditionMessingAtLeastAtMost() throws Exception {
         Duration duration = measureDuration(() ->
             await()
                 .during(1, SECONDS)
@@ -512,12 +547,11 @@ public class AwaitilityTest {
     }
 
     @Test
-    public void throwsIAEWhenTimeoutIsTooLargeForTheUnit() {
+    void throwsIAEWhenTimeoutIsTooLargeForTheUnit() {
         int timeoutMinutes = Integer.MAX_VALUE;
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Cannot convert " + timeoutMinutes + " MINUTES to nanoseconds, as required by Awaitility, because this value is too large");
-
-        Awaitility.await().atMost(timeoutMinutes, TimeUnit.MINUTES).until(() -> true);
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+            Awaitility.await().atMost(timeoutMinutes, TimeUnit.MINUTES).until(() -> true));
+        assertThat(exception.getMessage(), containsString("Cannot convert " + timeoutMinutes + " MINUTES to nanoseconds, as required by Awaitility, because this value is too large"));
     }
 
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {

--- a/awaitility/src/test/java/org/awaitility/BoxingTest.java
+++ b/awaitility/src/test/java/org/awaitility/BoxingTest.java
@@ -16,7 +16,7 @@
 
 package org.awaitility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -24,10 +24,10 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThan;
 
 @SuppressWarnings("UnnecessaryBoxing")
-public class BoxingTest {
+class BoxingTest {
 
     @Test
-    public void non_primitive_numbers_are_successfully_matched_against_their_primitive_counter_parts() {
+    void non_primitive_numbers_are_successfully_matched_against_their_primitive_counter_parts() {
         AtomicInteger ai = new AtomicInteger(0);
 
         new Thread(() -> {

--- a/awaitility/src/test/java/org/awaitility/ConditionEvaluationListenerTest.java
+++ b/awaitility/src/test/java/org/awaitility/ConditionEvaluationListenerTest.java
@@ -19,10 +19,9 @@ package org.awaitility;
 import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.EvaluatedCondition;
 import org.awaitility.core.StartEvaluationEvent;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -30,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.setDefaultConditionEvaluationListener;
 import static org.awaitility.Awaitility.with;
@@ -37,28 +37,30 @@ import static org.awaitility.Durations.ONE_SECOND;
 import static org.awaitility.Durations.TEN_SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class ConditionEvaluationListenerTest {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class ConditionEvaluationListenerTest {
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         Awaitility.reset();
     }
 
-    @Test(expected = RuntimeException.class)
-    public void listenerExceptionsAreNotCaught() {
-        with()
-                .catchUncaughtExceptions()
-                .conditionEvaluationListener(condition -> {
-                    throw new RuntimeException();
-                })
-                .until(new CountDown(10), is(equalTo(0)));
+    @Test
+    void listenerExceptionsAreNotCaught() {
+        assertThrows(RuntimeException.class, () ->
+            with()
+                    .catchUncaughtExceptions()
+                    .conditionEvaluationListener(condition -> {
+                        throw new RuntimeException();
+                    })
+                    .until(new CountDown(10), is(equalTo(0))));
     }
 
-    @Test(timeout = 2000)
-    public void settingDefaultHandlerWillImpactAllAwaitStatements() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void settingDefaultHandlerWillImpactAllAwaitStatements() {
 
         final CountDown globalCountDown = new CountDown(20);
 
@@ -79,8 +81,9 @@ public class ConditionEvaluationListenerTest {
         assertThat(globalCountDown.get(), is(equalTo(10)));
     }
 
-    @Test(timeout = 2000)
-    public void defaultHandlerCanBeDisabledPerAwaitStatement() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void defaultHandlerCanBeDisabledPerAwaitStatement() {
 
         final CountDown globalCountDown = new CountDown(20);
 
@@ -106,8 +109,9 @@ public class ConditionEvaluationListenerTest {
         assertThat(globalCountDown.get(), is(equalTo(10)));
     }
 
-    @Test(timeout = 2000)
-    public void afterAwaitilityResetNoDefaultHandlerIsSet() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void afterAwaitilityResetNoDefaultHandlerIsSet() {
         final CountDown globalCountDown = new CountDown(20);
 
         ConditionEvaluationListener defaultConditionEvaluationListener = condition -> {
@@ -129,8 +133,9 @@ public class ConditionEvaluationListenerTest {
         assertThat(globalCountDown.get(), is(equalTo(15)));
     }
 
-    @Test(timeout = 10000)
-    public void conditionResultsCanBeLoggedToSystemOut() {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void conditionResultsCanBeLoggedToSystemOut() {
         with()
                 .conditionEvaluationListener(condition -> {
                     if (condition.isSatisfied()) {
@@ -144,8 +149,9 @@ public class ConditionEvaluationListenerTest {
                 .until(new CountDown(5), is(equalTo(0)));
     }
 
-    @Test(timeout = 2000)
-    public void conditionResultsCanBeBuffered() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void conditionResultsCanBeBuffered() {
         final List<String> buffer = new ArrayList<>();
         with()
                 .conditionEvaluationListener(condition -> {
@@ -158,8 +164,9 @@ public class ConditionEvaluationListenerTest {
     }
 
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessageForComplexMatchers() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void expectedMismatchMessageForComplexMatchers() {
         final ValueHolder<String> lastMismatchMessage = new ValueHolder<>();
         with()
                 .conditionEvaluationListener((ConditionEvaluationListener<CountDownBean>) condition -> {
@@ -174,8 +181,9 @@ public class ConditionEvaluationListenerTest {
 
     }
 
-    @Test(timeout = 2000)
-    public void expectedMismatchMessage() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void expectedMismatchMessage() {
         final ValueHolder<String> lastMismatchMessage = new ValueHolder<>();
         with()
                 .conditionEvaluationListener(condition -> {
@@ -190,8 +198,9 @@ public class ConditionEvaluationListenerTest {
 
     }
 
-    @Test(timeout = 2000)
-    public void expectedMatchMessage() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void expectedMatchMessage() {
         final ValueHolder<String> lastMatchMessage = new ValueHolder<>();
         with()
                 .conditionEvaluationListener(condition -> lastMatchMessage.value = condition.getDescription())
@@ -201,8 +210,9 @@ public class ConditionEvaluationListenerTest {
         assertThat(lastMatchMessage.value, is(equalTo(expectedMatchMessage)));
     }
 
-    @Test(timeout = 2000)
-    public void beforeEvaluationCalledOnce() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void beforeEvaluationCalledOnce() {
         final ValueHolder<BigInteger> beforeEvaluation = new ValueHolder<>();
         beforeEvaluation.value = BigInteger.ZERO;
 
@@ -228,8 +238,9 @@ public class ConditionEvaluationListenerTest {
         assertThat(beforeEvaluation.value, is(equalTo(BigInteger.ONE)));
     }
 
-    @Test(timeout = 2000)
-    public void awaitingForeverReturnsLongMaxValueAsRemainingTime() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void awaitingForeverReturnsLongMaxValueAsRemainingTime() {
         final Set<Long> remainingTimes = new HashSet<>();
         final Set<Long> elapsedTimes = new HashSet<>();
         with()

--- a/awaitility/src/test/java/org/awaitility/DeadlockDetectionTest.java
+++ b/awaitility/src/test/java/org/awaitility/DeadlockDetectionTest.java
@@ -18,20 +18,26 @@ package org.awaitility;
 
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.DeadlockException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_SECOND;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class DeadlockDetectionTest {
+class DeadlockDetectionTest {
 
-    @Test(timeout = 2000L)
-    public void deadlockTest() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void deadlockTest() {
         final ReentrantLock lock1 = new ReentrantLock();
         final ReentrantLock lock2 = new ReentrantLock();
 

--- a/awaitility/src/test/java/org/awaitility/ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest.java
+++ b/awaitility/src/test/java/org/awaitility/ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest.java
@@ -20,18 +20,18 @@ import org.awaitility.classes.Asynch;
 import org.awaitility.classes.FakeRepository;
 import org.awaitility.classes.FakeRepositoryImpl;
 import org.awaitility.classes.ThrowExceptionUnlessFakeRepositoryEqualsOne;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-public class ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest {
+class ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest {
 
     private static FakeRepository fakeRepository = new FakeRepositoryImpl();
 
-    @BeforeClass
-    public static void exceptionThrowingSetupStep() {
+    @BeforeAll
+    static void exceptionThrowingSetupStep() {
         new Asynch(fakeRepository).perform();
         Awaitility
                 .with().ignoreExceptions()
@@ -45,7 +45,7 @@ public class ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest {
     }
 
     @Test
-    public void exceptionsInTestSetupAreIgnoredWhenIgnoringExceptions() {
+    void exceptionsInTestSetupAreIgnoredWhenIgnoringExceptions() {
         // nothing here, test logic sits in @BeforeClass method
     }
 }

--- a/awaitility/src/test/java/org/awaitility/FailFastTest.java
+++ b/awaitility/src/test/java/org/awaitility/FailFastTest.java
@@ -20,18 +20,18 @@ import org.awaitility.core.TerminalFailureException;
 import org.awaitility.core.ThrowingRunnable;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Fast failure on terminal status #178
@@ -40,223 +40,228 @@ import static org.hamcrest.Matchers.*;
  * <p>
  * PR https://github.com/awaitility/awaitility/pull/193
  */
-public class FailFastTest {
+class FailFastTest {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @After
-    public void reset_awaitility_after_each_test() {
+    @AfterEach
+    void reset_awaitility_after_each_test() {
         Awaitility.reset();
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_with_the_supplied_failure_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("System crash"));
+    void fail_fast_throws_terminal_failure_exception_with_the_supplied_failure_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
+            // pretend that 10 is a terminal failure
+            Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
 
-        await().timeout(Duration.ofSeconds(5))
-                .failFast("System crash", failFastCondition)
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .failFast("System crash", failFastCondition)
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), equalTo("System crash"));
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_with_the_default_failure_reason_when_no_failure_reason_is_specified() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("Fail fast condition triggered"));
+    void fail_fast_throws_terminal_failure_exception_with_the_default_failure_reason_when_no_failure_reason_is_specified() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
+            // pretend that 10 is a terminal failure
+            Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
 
-        await().timeout(Duration.ofSeconds(5))
-                .failFast(failFastCondition)
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .failFast(failFastCondition)
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), equalTo("Fail fast condition triggered"));
     }
 
     @Test
-    public void statically_configured_fail_fast_condition_without_failure_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("Fail fast condition triggered"));
+    void statically_configured_fail_fast_condition_without_failure_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
-        Awaitility.setDefaultFailFastCondition(failFastCondition);
+            // pretend that 10 is a terminal failure
+            Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
+            Awaitility.setDefaultFailFastCondition(failFastCondition);
 
-        await().timeout(Duration.ofSeconds(5))
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .until(ai::get, equalTo(-1));// will never be true
+        });
+        assertThat(exception.getMessage(), equalTo("Fail fast condition triggered"));
     }
 
     @Test
-    public void statically_configured_fail_fast_condition_with_failure_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("System crash"));
+    void statically_configured_fail_fast_condition_with_failure_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
-        Awaitility.setDefaultFailFastCondition("System crash", failFastCondition);
+            // pretend that 10 is a terminal failure
+            Callable<Boolean> failFastCondition = () -> ai.get() >= 10;
+            Awaitility.setDefaultFailFastCondition("System crash", failFastCondition);
 
-        await().timeout(Duration.ofSeconds(5))
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), equalTo("System crash"));
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_assertions_without_explicit_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(containsString("was less than <10>"));
+    void fail_fast_throws_terminal_failure_exception_without_reason_when_using_assertions_without_explicit_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
+            // pretend that 10 is a terminal failure
+            ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
 
-        await().timeout(Duration.ofSeconds(5))
-                .failFast(failFastAssertion)
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .failFast(failFastAssertion)
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), containsString("was less than <10>"));
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_default_assertions_without_explicit_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage(containsString("was less than <10>"));
+    void fail_fast_throws_terminal_failure_exception_without_reason_when_using_default_assertions_without_explicit_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
-        Awaitility.setDefaultFailFastCondition(failFastAssertion);
+            // pretend that 10 is a terminal failure
+            ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
+            Awaitility.setDefaultFailFastCondition(failFastAssertion);
 
-        await().timeout(Duration.ofSeconds(5))
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), containsString("was less than <10>"));
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_assertions_with_explicit_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage("fail fast reason");
-        exception.expectCause(instanceOf(AssertionError.class));
+    void fail_fast_throws_terminal_failure_exception_without_reason_when_using_assertions_with_explicit_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
+            // pretend that 10 is a terminal failure
+            ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
 
-        await().timeout(Duration.ofSeconds(5))
-                .failFast("fail fast reason", failFastAssertion)
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .failFast("fail fast reason", failFastAssertion)
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), containsString("fail fast reason"));
+        assertThat(exception.getCause(), instanceOf(AssertionError.class));
     }
 
     @Test
-    public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_default_assertions_with_explicit_reason() {
-        exception.expect(TerminalFailureException.class);
-        exception.expectMessage("fail fast reason");
-        exception.expectCause(instanceOf(AssertionError.class));
+    void fail_fast_throws_terminal_failure_exception_without_reason_when_using_default_assertions_with_explicit_reason() {
+        Throwable exception = assertThrows(TerminalFailureException.class, () -> {
 
-        AtomicInteger ai = new AtomicInteger(0);
+            AtomicInteger ai = new AtomicInteger(0);
 
-        new Thread(() -> {
-            while (true) {
-                ai.incrementAndGet();
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+            new Thread(() -> {
+                while (true) {
+                    ai.incrementAndGet();
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-            }
-        }).start();
+            }).start();
 
-        // pretend that 10 is a terminal failure
-        ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
-        Awaitility.setDefaultFailFastCondition("fail fast reason", failFastAssertion);
+            // pretend that 10 is a terminal failure
+            ThrowingRunnable failFastAssertion = () -> assertThat(ai.get(), greaterThan(10));
+            Awaitility.setDefaultFailFastCondition("fail fast reason", failFastAssertion);
 
-        await().timeout(Duration.ofSeconds(5))
-                .until(ai::get, equalTo(-1)); // will never be true
+            await().timeout(Duration.ofSeconds(5))
+                    .until(ai::get, equalTo(-1)); // will never be true
+        });
+        assertThat(exception.getMessage(), containsString("fail fast reason"));
+        assertThat(exception.getCause(), instanceOf(AssertionError.class));
     }
 }

--- a/awaitility/src/test/java/org/awaitility/UsingAtomicTest.java
+++ b/awaitility/src/test/java/org/awaitility/UsingAtomicTest.java
@@ -19,124 +19,141 @@ import org.awaitility.classes.Asynch;
 import org.awaitility.classes.FakeRepository;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.JavaVersionDetector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class UsingAtomicTest {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class UsingAtomicTest {
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         Awaitility.reset();
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicInteger() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicInteger() {
         AtomicInteger atomic = new AtomicInteger(0);
         new Asynch(new FakeRepositoryWithAtomicInteger(atomic)).perform();
         await().untilAtomic(atomic, equalTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicIntegerWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicIntegerWithConsumerMatcher() {
         AtomicInteger atomic = new AtomicInteger(0);
         new Asynch(new FakeRepositoryWithAtomicInteger(atomic)).perform();
         await().untilAtomic(atomic, value -> assertThat(value).isEqualTo(1));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicIntegerAndTimeout() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("expected <1> but was <0> within 200 milliseconds.");
-        AtomicInteger atomic = new AtomicInteger(0);
-        await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(1));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicIntegerAndTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            AtomicInteger atomic = new AtomicInteger(0);
+            await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(1));
+        });
+        assertThat(exception.getMessage(), containsString("expected <1> but was <0> within 200 milliseconds."));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicBoolean() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicBoolean() {
         AtomicBoolean atomic = new AtomicBoolean(false);
         new Asynch(new FakeRepositoryWithAtomicBoolean(atomic)).perform();
         await().untilAtomic(atomic, equalTo(true));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicBooleanWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicBooleanWithConsumerMatcher() {
         AtomicBoolean atomic = new AtomicBoolean(false);
         new Asynch(new FakeRepositoryWithAtomicBoolean(atomic)).perform();
         await().untilAtomic(atomic, value -> assertThat(value).isTrue());
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicBooleanAndTimeout() {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("expected <true> but was <false> within 200 milliseconds.");
-        AtomicBoolean atomic = new AtomicBoolean(false);
-        await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(true));
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicBooleanAndTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            AtomicBoolean atomic = new AtomicBoolean(false);
+            await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(true));
+        });
+        assertThat(exception.getMessage(), containsString("expected <true> but was <false> within 200 milliseconds."));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicLong() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicLong() {
         AtomicLong atomic = new AtomicLong(0);
         new Asynch(new FakeRepositoryWithAtomicLong(atomic)).perform();
         await().untilAtomic(atomic, equalTo(1L));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicLongWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicLongWithConsumerMatcher() {
         AtomicLong atomic = new AtomicLong(0);
         new Asynch(new FakeRepositoryWithAtomicLong(atomic)).perform();
         await().untilAtomic(atomic, value -> assertThat(value).isEqualTo(1L));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicLongAndTimeout() {
-        exception.expect(ConditionTimeoutException.class);
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicLongAndTimeout() {
         String message = JavaVersionDetector.getJavaMajorVersion() < 17 ?
                 "Lambda expression in org.awaitility.core.ConditionFactory that uses java.util.concurrent.atomic.AtomicLong: expected <1L> but was <0L> within 200 milliseconds."
                 : "Lambda expression in org.awaitility.core.ConditionFactory expected <1L> but was <0L> within 200 milliseconds.";
-        exception.expectMessage(message);
-        AtomicLong atomic = new AtomicLong(0);
-        await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(1L));
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            AtomicLong atomic = new AtomicLong(0);
+            await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo(1L));
+        });
+        assertThat(exception.getMessage(), containsString(message));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicReference() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicReference() {
         AtomicReference<String> atomic = new AtomicReference<>("0");
         new Asynch(new FakeRepositoryWithAtomicReference(atomic)).perform();
         await().untilAtomic(atomic, equalTo("1"));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicReferenceWithConsumerMatcher() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicReferenceWithConsumerMatcher() {
         AtomicReference<String> atomic = new AtomicReference<>("0");
         new Asynch(new FakeRepositoryWithAtomicReference(atomic)).perform();
         await().untilAtomic(atomic, value -> assertThat(value).isEqualTo("1"));
     }
 
-    @Test(timeout = 2000)
-    public void usingAtomicReferenceAndTimeout() {
-        exception.expect(ConditionTimeoutException.class);
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void usingAtomicReferenceAndTimeout() {
         String message = JavaVersionDetector.getJavaMajorVersion() < 17 ?
                 "Lambda expression in org.awaitility.core.ConditionFactory that uses java.util.concurrent.atomic.AtomicReference: expected \"1\" but was \"0\" within 200 milliseconds."
                 : "Lambda expression in org.awaitility.core.ConditionFactory expected \"1\" but was \"0\" within 200 milliseconds.";
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            AtomicReference<String> atomic = new AtomicReference<>("0");
+            await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo("1"));
+        });
 
-        exception.expectMessage(message);
-        AtomicReference<String> atomic = new AtomicReference<>("0");
-        await().atMost(200, MILLISECONDS).untilAtomic(atomic, equalTo("1"));
+        assertThat(exception.getMessage(), containsString(message));
     }
 }
 

--- a/awaitility/src/test/java/org/awaitility/UsingFieldSupplierTest.java
+++ b/awaitility/src/test/java/org/awaitility/UsingFieldSupplierTest.java
@@ -18,53 +18,59 @@ package org.awaitility;
 import org.awaitility.classes.*;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.reflect.exception.FieldNotFoundException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.fieldIn;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class UsingFieldSupplierTest {
+class UsingFieldSupplierTest {
     private FakeRepository fakeRepository;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         fakeRepository = new FakeRepositoryImpl();
         Awaitility.reset();
     }
 
-    
-    @Test(timeout = 2000)
-    public void ofTypeAndName() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void ofTypeAndName() throws Exception {
         new Asynch(fakeRepository).perform();
         await().until(fieldIn(fakeRepository).ofType(int.class).andWithName("value"), equalTo(1));
         assertEquals(1, fakeRepository.getValue());
     }
-    @Test(timeout = 2000)
-    public void typeOnly() throws Exception {
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void typeOnly() throws Exception {
         new Asynch(fakeRepository).perform();
         await().until(fieldIn(fakeRepository).ofType(int.class), equalTo(1));
         assertEquals(1, fakeRepository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void typeAndAnnotation() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void typeAndAnnotation() throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         await().until(fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation.class), equalTo(1));
         assertEquals(1, repository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void typeAndNameAndAnnotation() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void typeAndNameAndAnnotation() throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         await().until(
@@ -73,8 +79,9 @@ public class UsingFieldSupplierTest {
         assertEquals(1, repository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void typeAndAnnotationAndName() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void typeAndAnnotationAndName() throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         await().until(
@@ -83,8 +90,9 @@ public class UsingFieldSupplierTest {
         assertEquals(1, repository.getValue());
     }
 
-    @Test(timeout = 2000)
-    public void givenStaticFieldAndUsingOfTypeAndName() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenStaticFieldAndUsingOfTypeAndName() throws Exception {
         FakeRepositoryWithStaticFieldAndAnnotation repository = new FakeRepositoryWithStaticFieldAndAnnotation();
         new Asynch(repository).perform();
         await().until(fieldIn(FakeRepositoryWithStaticFieldAndAnnotation.class).ofType(int.class).andWithName("value"),
@@ -92,131 +100,130 @@ public class UsingFieldSupplierTest {
         assertEquals(1, repository.getValue());
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenStaticFieldAndUsingOfTypeAndNameThrowsFieldNotFoundExceptionWhenUsingInstance() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenStaticFieldAndUsingOfTypeAndNameThrowsFieldNotFoundExceptionWhenUsingInstance() throws Exception {
         FakeRepositoryWithStaticFieldAndAnnotation repository = new FakeRepositoryWithStaticFieldAndAnnotation();
         new Asynch(repository).perform();
-        await().until(fieldIn(repository).ofType(int.class).andWithName("value"), equalTo(1));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(int.class).andWithName("value"), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndNameWhenNameMatchButTypeDoesntThenFieldNotFoundExceptionIsThrown() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndNameWhenNameMatchButTypeDoesntThenFieldNotFoundExceptionIsThrown() throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         byte one = (byte) 1;
-        await().until(fieldIn(repository).ofType(byte.class).andWithName("value"), equalTo(one));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(byte.class).andWithName("value"), equalTo(one)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndNameWhenTypeMatchButNameDoesntThenFieldNotFoundExceptionIsThrown() throws Exception {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndNameWhenTypeMatchButNameDoesntThenFieldNotFoundExceptionIsThrown() throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
-        await().until(fieldIn(repository).ofType(int.class).andWithName("value2"), equalTo(1));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(int.class).andWithName("value2"), equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndNameAndAnnotationWhenNameAndTypeMatchButAnnotationNotFoundThenFieldNotFoundExceptionIsThrown()
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndNameAndAnnotationWhenNameAndTypeMatchButAnnotationNotFoundThenFieldNotFoundExceptionIsThrown()
             throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
-        await().until(
-                fieldIn(repository).ofType(int.class).andWithName("value").andAnnotatedWith(ExampleAnnotation2.class),
-                equalTo(1));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () ->await().until(
+                    fieldIn(repository).ofType(int.class).andWithName("value").andAnnotatedWith(ExampleAnnotation2.class),
+                    equalTo(1)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndNameAndAnnotationWhenNameAndAnnotationMatchButTypeNotFoundThenFieldNotFoundExceptionIsThrown()
-            throws Exception {
-        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
-        new Asynch(repository).perform();
-        byte one = (byte) 1;
-        await().until(fieldIn(repository).ofType(byte.class).andWithName("value").andAnnotatedWith(ExampleAnnotation.class),
-                equalTo(one));
-        assertEquals(1, repository.getValue());
-    }
-
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndAnnotationAndNameWhenNameAndTypeMatchButAnnotationNotFoundThenFieldNotFoundExceptionIsThrown()
-            throws Exception {
-        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
-        new Asynch(repository).perform();
-        await().until(
-                fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation2.class).andWithName("value"),
-                equalTo(1));
-        assertEquals(1, repository.getValue());
-    }
-
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenTypeAndAnnotationAndNameWhenNameAndAnnotationMatchButTypeNotFoundThenFieldNotFoundExceptionIsThrown()
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndNameAndAnnotationWhenNameAndAnnotationMatchButTypeNotFoundThenFieldNotFoundExceptionIsThrown()
             throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         byte one = (byte) 1;
-        await().until(fieldIn(repository).ofType(byte.class).andAnnotatedWith(ExampleAnnotation.class).andWithName("value"),
-                equalTo(one));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(byte.class).andWithName("value").andAnnotatedWith(ExampleAnnotation.class),
+                    equalTo(one)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenAnnotationAndTypeWhenAnnotationMatchButTypeDoesntThenFieldNotFoundExceptionIsThrown()
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndAnnotationAndNameWhenNameAndTypeMatchButAnnotationNotFoundThenFieldNotFoundExceptionIsThrown()
+            throws Exception {
+        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
+        new Asynch(repository).perform();
+        assertThrows(FieldNotFoundException.class, () -> await().until(
+                    fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation2.class).andWithName("value"),
+                    equalTo(1)));
+    }
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenTypeAndAnnotationAndNameWhenNameAndAnnotationMatchButTypeNotFoundThenFieldNotFoundExceptionIsThrown()
             throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
         byte one = (byte) 1;
-        await().until(fieldIn(repository).ofType(byte.class).andAnnotatedWith(ExampleAnnotation.class), equalTo(one));
-        assertEquals(1, repository.getValue());
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(byte.class).andAnnotatedWith(ExampleAnnotation.class).andWithName("value"),
+                    equalTo(one)));
     }
 
-    @Test(timeout = 2000, expected = FieldNotFoundException.class)
-    public void givenAnnotationAndTypeWhenTypeMatchButAnnotationDoesntThenFieldNotFoundExceptionIsThrown()
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenAnnotationAndTypeWhenAnnotationMatchButTypeDoesntThenFieldNotFoundExceptionIsThrown()
             throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
-        await().until(fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation2.class), equalTo(1));
-        assertEquals(1, repository.getValue());
+        byte one = (byte) 1;
+        assertThrows(FieldNotFoundException.class, () -> await().until(fieldIn(repository).ofType(byte.class).andAnnotatedWith(ExampleAnnotation.class), equalTo(one)));
     }
 
     @Test
-    public void showsErrorMessageContainingClassAndTypeWhenOnlyTypeSpecifiedWhenTimeout() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Field in org.awaitility.classes.FakeRepositoryWithAnnotation of type int expected <1> but was <0> within 200 milliseconds.");
-
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void givenAnnotationAndTypeWhenTypeMatchButAnnotationDoesntThenFieldNotFoundExceptionIsThrown()
+            throws Exception {
         FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
         new Asynch(repository).perform();
-        await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class), equalTo(1));
     }
 
     @Test
-    public void showsErrorMessageContainingClassAndTypeAndFieldNameWhenTypeAndNameSpecifiedWhenTimeout() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Field private volatile int org.awaitility.classes.FakeRepositoryWithAnnotation.value expected <1> but was <0> within 200 milliseconds.");
-
-        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
-        new Asynch(repository).perform();
-        await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andWithName("value"), equalTo(1));
+    void showsErrorMessageContainingClassAndTypeWhenOnlyTypeSpecifiedWhenTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
+            new Asynch(repository).perform();
+            await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class), equalTo(1));
+        });
+        assertThat(exception.getMessage(), containsString("Field in org.awaitility.classes.FakeRepositoryWithAnnotation of type int expected <1> but was <0> within 200 milliseconds."));
     }
 
     @Test
-    public void showsErrorMessageContainingClassAndTypeAndFieldNameAndAnnotationWhenTypeAndNameAndAnnotationTypeSpecifiedWhenTimeout() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Field private volatile int org.awaitility.classes.FakeRepositoryWithAnnotation.value expected <1> but was <0> within 200 milliseconds.");
-
-        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
-        new Asynch(repository).perform();
-        await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andWithName("value").andAnnotatedWith(ExampleAnnotation.class), equalTo(1));
+    void showsErrorMessageContainingClassAndTypeAndFieldNameWhenTypeAndNameSpecifiedWhenTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
+            new Asynch(repository).perform();
+            await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andWithName("value"), equalTo(1));
+        });
+        assertThat(exception.getMessage(), containsString("Field private volatile int org.awaitility.classes.FakeRepositoryWithAnnotation.value expected <1> but was <0> within 200 milliseconds."));
     }
 
     @Test
-    public void showsErrorMessageContainingClassAndTypeAndAnnotationWhenTypeAndAnnotationTypeSpecifiedWhenTimeout() throws Exception {
-        exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage("Field in org.awaitility.classes.FakeRepositoryWithAnnotation annotated with org.awaitility.classes.ExampleAnnotation and of type int expected <1> but was <0> within 200 milliseconds.");
+    void showsErrorMessageContainingClassAndTypeAndFieldNameAndAnnotationWhenTypeAndNameAndAnnotationTypeSpecifiedWhenTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
+            new Asynch(repository).perform();
+            await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andWithName("value").andAnnotatedWith(ExampleAnnotation.class), equalTo(1));
+        });
+        assertThat(exception.getMessage(), containsString("Field private volatile int org.awaitility.classes.FakeRepositoryWithAnnotation.value expected <1> but was <0> within 200 milliseconds."));
+    }
 
-        FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
-        new Asynch(repository).perform();
-        await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation.class), equalTo(1));
+    @Test
+    void showsErrorMessageContainingClassAndTypeAndAnnotationWhenTypeAndAnnotationTypeSpecifiedWhenTimeout() {
+        Throwable exception = assertThrows(ConditionTimeoutException.class, () -> {
+            FakeRepositoryWithAnnotation repository = new FakeRepositoryWithAnnotation();
+            new Asynch(repository).perform();
+            await().atMost(200, MILLISECONDS).until(fieldIn(repository).ofType(int.class).andAnnotatedWith(ExampleAnnotation.class), equalTo(1));
+        });
+        assertThat(exception.getMessage(), containsString("Field in org.awaitility.classes.FakeRepositoryWithAnnotation annotated with org.awaitility.classes.ExampleAnnotation and of type int expected <1> but was <0> within 200 milliseconds."));
     }
 }

--- a/awaitility/src/test/java/org/awaitility/WaitForAtomicBooleanTest.java
+++ b/awaitility/src/test/java/org/awaitility/WaitForAtomicBooleanTest.java
@@ -16,49 +16,56 @@
 
 package org.awaitility;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class WaitForAtomicBooleanTest {
+class WaitForAtomicBooleanTest {
     private AtomicBoolean wasAdded;
     private AtomicBoolean wasAddedWithDefaultValue;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         wasAdded = new AtomicBoolean(false);
         wasAddedWithDefaultValue = new AtomicBoolean();
     }
 
-    @Test(timeout = 2000L)
-    public void atomicBooleanExample() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void atomicBooleanExample() {
         new WasAddedModifier().start();
 
         await().atMost(FIVE_SECONDS).until(wasAdded(), equalTo(true));
     }
 
-    @Test(timeout = 2000L)
-    public void atomicBooleanWithUntilTrueWhenBooleanUsesDefaultValue() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void atomicBooleanWithUntilTrueWhenBooleanUsesDefaultValue() {
         new WasAddedWithDefaultValue().start();
 
         await().atMost(FIVE_SECONDS).untilTrue(wasAddedWithDefaultValue);
     }
 
-    @Test(timeout = 2000L)
-    public void atomicBooleanWithUntilTrue() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void atomicBooleanWithUntilTrue() {
         new WasAddedModifier().start();
 
         await().atMost(FIVE_SECONDS).untilTrue(wasAdded);
     }
 
-    @Test(timeout = 2000L)
-    public void atomicBooleanWithUntilFalse() {
+    @Test
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void atomicBooleanWithUntilFalse() {
         wasAdded.set(true);
         new WasAddedModifier().start();
 

--- a/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionAwaiterTest.java
@@ -1,7 +1,7 @@
 
 package org.awaitility.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -10,21 +10,18 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ConditionAwaiterTest {
-
+class ConditionAwaiterTest {
 
     /**
      * Asserts that https://github.com/awaitility/awaitility/issues/95 is resolved
      */
-    @Test public void
-    calculates_a_duration_of_1_nano_when_system_nano_time_is_skewed() {
+    @Test void calculates_a_duration_of_1_nano_when_system_nano_time_is_skewed() {
         Duration duration = ConditionAwaiter.calculateConditionEvaluationDuration(Duration.ofNanos(10000000L), System.nanoTime(), 0, Duration.ofNanos(0), Duration.ofNanos(0));
 
         assertThat(duration.toNanos(), is(1L));
     }
 
-
-    @Test public void atLeastIncludesPollDelayWithPollInterval() {
+    @Test void atLeastIncludesPollDelayWithPollInterval() {
         long start = System.currentTimeMillis();
         await()
                 .pollDelay(Duration.ofMillis(100))
@@ -36,8 +33,7 @@ public class ConditionAwaiterTest {
     /**
      * Asserts that https://github.com/awaitility/awaitility/issues/152 is resolved
      */
-    @Test public void
-    originalUncaughtExceptionHandlerIsSetBackAfterConditionEvaluation() {
+    @Test void originalUncaughtExceptionHandlerIsSetBackAfterConditionEvaluation() {
         Thread.UncaughtExceptionHandler originalUncaughtExceptionHandler = (t, e) -> {};
         Thread.setDefaultUncaughtExceptionHandler(originalUncaughtExceptionHandler);
 
@@ -50,8 +46,7 @@ public class ConditionAwaiterTest {
         assertThat(Thread.getDefaultUncaughtExceptionHandler(), is(originalUncaughtExceptionHandler));
     }
 
-    @Test
-    public void shouldHandleImmediateResultWithAtMost(){
+    @Test void shouldHandleImmediateResultWithAtMost(){
         await().atMost(Duration.ofMillis(10)).pollInterval(Duration.ofMillis(5)).until(() -> true);
     }
 }

--- a/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
@@ -17,13 +17,15 @@
 package org.awaitility.core;
 
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
@@ -31,14 +33,15 @@ import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.core.ConditionEvaluationLogger.conditionEvaluationLogger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
-public class ConditionEvaluationLoggerTest {
+class ConditionEvaluationLoggerTest {
 
     private final PrintStream standardOut = System.out;
 
-    @After
+    @AfterEach
     @SuppressWarnings("unused")
-    public void resetDefaultSystemOut() {
+    void resetDefaultSystemOut() {
         System.setOut(standardOut);
         Awaitility.reset();
     }
@@ -46,8 +49,9 @@ public class ConditionEvaluationLoggerTest {
     /**
      * Test should check that await.logging(Consumer) properly logging data to Consumer
      */
-    @Test(timeout = 2000)
-    public void it_is_possible_to_use_logging_with_syntactic_sugar_via_condition_evaluation_logger_by_consumer() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_use_logging_with_syntactic_sugar_via_condition_evaluation_logger_by_consumer() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
 
         await().with()
@@ -70,8 +74,9 @@ public class ConditionEvaluationLoggerTest {
     /**
      * Test should check that Awaitility.setLoggingListener(new ConditionEvaluationLogger(Consumer)) properly logging data to Consumer
      */
-    @Test(timeout = 2000)
-    public void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_condition_evaluation_logger_by_consumer() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_condition_evaluation_logger_by_consumer() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
         Awaitility.setLoggingListener(new ConditionEvaluationLogger(logs::add));
 
@@ -94,8 +99,9 @@ public class ConditionEvaluationLoggerTest {
     /**
      * Test should check that Awaitility.setLogging(new ConditionEvaluationLogger(Consumer)) properly logging data to Consumer
      */
-    @Test(timeout = 2000)
-    public void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_consumer() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_use_logging_with_Awaitlity_static_settings_via_consumer() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
         Awaitility.setLogging(logs::add);
 
@@ -118,8 +124,9 @@ public class ConditionEvaluationLoggerTest {
     /**
      * Test should check that await.logging() properly logging data to System.out
      */
-    @Test(timeout = 2000)
-    public void it_is_possible_to_use_sout_logging_with_syntactic_sugar_via_condition_evaluation_logger() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_use_sout_logging_with_syntactic_sugar_via_condition_evaluation_logger() {
         final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStreamCaptor));
         final AtomicInteger stub = new AtomicInteger(0);
@@ -144,8 +151,9 @@ public class ConditionEvaluationLoggerTest {
     /**
      * Test should check that Awaitility.setDefaultLogging() properly logging data to System.out
      */
-    @Test(timeout = 2000)
-    public void it_is_possible_to_use_sout_logging_with_Awaitility_static_settings_via_condition_evaluation_logger() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_use_sout_logging_with_Awaitility_static_settings_via_condition_evaluation_logger() {
         final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStreamCaptor));
         final AtomicInteger stub = new AtomicInteger(0);
@@ -168,8 +176,9 @@ public class ConditionEvaluationLoggerTest {
         );
     }
 
-    @Test(timeout = 2000)
-    public void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_ctor_to_create_the_condition_evaluation_logger() {
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_ctor_to_create_the_condition_evaluation_logger() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
 
         await().with().conditionEvaluationListener(new ConditionEvaluationLogger(logs::add)).
@@ -178,9 +187,10 @@ public class ConditionEvaluationLoggerTest {
 
         assertThat(logs, everyItem(anyOf(equalTo("Starting evaluation"), containsString("expected <4> but was"), containsString("reached its end value of <4>"))));
     }
-    
-    @Test(timeout = 2000)
-    public void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_static_method_to_create_the_condition_evaluation_logger() {
+
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS, threadMode = SEPARATE_THREAD)
+    void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_static_method_to_create_the_condition_evaluation_logger() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
 
         await().with().conditionEvaluationListener(conditionEvaluationLogger(logs::add)).

--- a/awaitility/src/test/java/org/awaitility/core/HamcrestToStringFilterTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/HamcrestToStringFilterTest.java
@@ -15,30 +15,30 @@
  */
 package org.awaitility.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class HamcrestToStringFilterTest {
+class HamcrestToStringFilterTest {
 
-	@Test
-	public void removesIsFromToString() throws Exception {
+    @Test
+    void removesIsFromToString() throws Exception {
 		assertEquals("<4>", HamcrestToStringFilter.filter(is(equalTo(4))));
 	}
 
-	@Test
-	public void removesNotNotFromToString() throws Exception {
+    @Test
+    void removesNotNotFromToString() throws Exception {
 		assertEquals("<4>", HamcrestToStringFilter.filter(not(not((equalTo(4))))));
 	}
 
-	@Test
-	public void removesAllNotNotsFromToString() throws Exception {
+    @Test
+    void removesAllNotNotsFromToString() throws Exception {
 		assertEquals("<4>", HamcrestToStringFilter.filter(not(not(not(not((equalTo(4))))))));
 	}
 
-	@Test
-	public void removesNotNotButKeepsRemainingNotFromToString() throws Exception {
+    @Test
+    void removesNotNotButKeepsRemainingNotFromToString() throws Exception {
 		assertEquals("not <4>", HamcrestToStringFilter.filter(not(not(not((equalTo(4)))))));
 	}
 }

--- a/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
@@ -1,24 +1,24 @@
 package org.awaitility.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class JavaVersionDetectorTest {
+class JavaVersionDetectorTest {
 
     @Test
-    public void nullJavaVersionDefaultsTo8() {
+    void nullJavaVersionDefaultsTo8() {
         assertThat(JavaVersionDetector.getJavaMajorVersion(null), equalTo(8));
     }
 
     @Test
-    public void emptyJavaVersionDefaultsTo8() {
+    void emptyJavaVersionDefaultsTo8() {
         assertThat(JavaVersionDetector.getJavaMajorVersion(""), equalTo(8));
     }
 
     @Test
-    public void javaVersionFor8() {
+    void javaVersionFor8() {
         /*
         docker run --rm -it eclipse-temurin:8-jdk bash
         echo 'class Scratch {
@@ -33,7 +33,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor11WithDot() {
+    void javaVersionFor11WithDot() {
         /*
         docker run --rm -it eclipse-temurin:11-jdk jshell
         System.getProperty("java.version")
@@ -42,7 +42,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor17WithDot() {
+    void javaVersionFor17WithDot() {
         /*
         docker run --rm -it eclipse-temurin:17-jdk jshell
         System.getProperty("java.version")
@@ -51,7 +51,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor21WithoutDot() {
+    void javaVersionFor21WithoutDot() {
         /*
         Until there is a first patch release, java.version reports a single number without dots.
          */
@@ -59,7 +59,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor21WithDot() {
+    void javaVersionFor21WithDot() {
         /*
         docker run --rm -it eclipse-temurin:21-jdk jshell
         System.getProperty("java.version")
@@ -68,7 +68,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor23ea() {
+    void javaVersionFor23ea() {
         /*
         OpenJDK EA reports java.version with ea suffix
          */
@@ -76,7 +76,7 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor23beta() {
+    void javaVersionFor23beta() {
         /*
         Temurin JDK EA reports java.version with beta suffix
          */

--- a/awaitility/src/test/java/org/awaitility/pollinterval/FibonacciPollIntervalTest.java
+++ b/awaitility/src/test/java/org/awaitility/pollinterval/FibonacciPollIntervalTest.java
@@ -16,19 +16,19 @@
 
 package org.awaitility.pollinterval;
 
+import org.junit.jupiter.api.Test;
+
 import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-public class FibonacciPollIntervalTest {
+class FibonacciPollIntervalTest {
 
-    @Test public void
-    fibonacci_small_number() {
+    @Test void fibonacci_small_number() {
         // Given
 
         // When
@@ -38,8 +38,7 @@ public class FibonacciPollIntervalTest {
         assertThat(fibonacci, is(55));
     }
 
-    @Test public void
-    fibonacci_large_number() {
+    @Test void fibonacci_large_number() {
         // Given
 
         // When
@@ -49,8 +48,7 @@ public class FibonacciPollIntervalTest {
         assertThat(fibonacci, is(428607904));
     }
 
-    @Test public void
-    next_default_offset() {
+    @Test void next_default_offset() {
         // Given
         Duration unused = Duration.ofMillis(ThreadLocalRandom.current().nextLong());
         FibonacciPollInterval pollInterval = new FibonacciPollInterval(TimeUnit.SECONDS);
@@ -62,8 +60,7 @@ public class FibonacciPollIntervalTest {
         assertThat(next, is(Duration.ofSeconds(1)));
     }
 
-    @Test public void
-    next_negative_offset() {
+    @Test void next_negative_offset() {
         // Given
         Duration unused = Duration.ofMillis(ThreadLocalRandom.current().nextLong());
         FibonacciPollInterval pollInterval = new FibonacciPollInterval(-1, TimeUnit.SECONDS);

--- a/pom.xml
+++ b/pom.xml
@@ -200,9 +200,9 @@
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.13.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

Tests in `awaitility-osgi-test` have not been migrated as they rely on `org.ops4j.pax.exam:pax-exam-junit4` for which there is no JUnit5 equivalent.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.