### PR TITLE
Add capability to ignore condition timeout

### DIFF
--- a/awaitility/src/main/java/org/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/org/awaitility/Awaitility.java
@@ -159,6 +159,12 @@ public class Awaitility {
     private static volatile FailFastCondition defaultFailFastCondition = null;
 
     /**
+     * Throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold.
+     */
+    private static volatile boolean defaultIgnoreConditionTimeout = false;
+
+    /**
      * Instruct Awaitility to catch uncaught exceptions from other threads by
      * default. This is useful in multi-threaded systems when you want your test
      * to fail regardless of which thread throwing the exception. Default is
@@ -257,7 +263,28 @@ public class Awaitility {
     }
 
     /**
-     * Reset the timeout, poll interval, poll delay, uncaught exception handling
+     * Instruct Awaitility to not throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold.
+     * This is not the default behavior,
+     * the default behavior is throwing an exception.
+     * @since 4.4.0
+     */
+    public static void ignoreConditionTimeoutByDefault() {
+        defaultIgnoreConditionTimeout = true;
+    }
+
+    /**
+     * Instruct Awaitility to throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold.
+     * This is the default behavior.
+     * @since 4.4.0
+     */
+    public static void doNotIgnoreConditionTimeoutByDefault() {
+        defaultIgnoreConditionTimeout = false;
+    }
+
+    /**
+     * Reset the timeout, poll interval, poll delay, uncaught exception handling, etc.
      * to their default values:
      * <p>&nbsp;</p>
      * <ul>
@@ -269,6 +296,8 @@ public class Awaitility {
      * <li>Don't handle condition evaluation results</li>
      * <li>Don't log anything</li>
      * <li>No fail fast condition</li>
+     * <li>Throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold</li>
      * </ul>
      */
     public static void reset() {
@@ -281,6 +310,7 @@ public class Awaitility {
         defaultExceptionIgnorer = new PredicateExceptionIgnorer(e -> false);
         defaultFailFastCondition = null;
         Thread.setDefaultUncaughtExceptionHandler(null);
+        defaultIgnoreConditionTimeout = false;
     }
 
     /**
@@ -304,7 +334,7 @@ public class Awaitility {
     public static ConditionFactory await(String alias) {
         return new ConditionFactory(alias, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -317,7 +347,7 @@ public class Awaitility {
     public static ConditionFactory catchUncaughtExceptions() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -329,7 +359,7 @@ public class Awaitility {
     public static ConditionFactory dontCatchUncaughtExceptions() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
                 false, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -344,7 +374,7 @@ public class Awaitility {
     public static ConditionFactory with() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -359,7 +389,7 @@ public class Awaitility {
     public static ConditionFactory given() {
         return new ConditionFactory(null, defaultWaitConstraint, defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -372,7 +402,7 @@ public class Awaitility {
     public static ConditionFactory waitAtMost(Duration timeout) {
         return new ConditionFactory(null, defaultWaitConstraint.withMaxWaitTime(timeout), defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**
@@ -386,7 +416,7 @@ public class Awaitility {
     public static ConditionFactory waitAtMost(long value, TimeUnit unit) {
         return new ConditionFactory(null, defaultWaitConstraint.withMaxWaitTime(DurationFactory.of(value, unit)), defaultPollInterval, defaultPollDelay,
                 defaultCatchUncaughtExceptions, defaultExceptionIgnorer, defaultConditionEvaluationListener,
-                defaultExecutorLifecycle, defaultFailFastCondition);
+                defaultExecutorLifecycle, defaultFailFastCondition, defaultIgnoreConditionTimeout);
     }
 
     /**

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -164,12 +164,16 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                     }
                 }
                 conditionEvaluationHandler.handleTimeout(message, false);
-                throw new ConditionTimeoutException(message, cause);
+                if (!conditionSettings.shouldIgnoreConditionTimeout()) {
+                    throw new ConditionTimeoutException(message, cause);
+                }
             } else if (evaluationDuration.compareTo(minWaitTime) < 0) {
                 String message = String.format("Condition was evaluated in %s which is earlier than expected minimum timeout %s",
                         formatAsString(evaluationDuration), formatAsString(minWaitTime));
                 conditionEvaluationHandler.handleTimeout(message, true);
-                throw new ConditionTimeoutException(message);
+                if (!conditionSettings.shouldIgnoreConditionTimeout()) {
+                    throw new ConditionTimeoutException(message);
+                }
             }
         } catch (Throwable e) {
             CheckedExceptionRethrower.safeRethrow(e);

--- a/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
@@ -91,6 +91,11 @@ public class ConditionFactory {
     private final FailFastCondition failFastCondition;
 
     /**
+     * Whether to throw a {@link ConditionTimeoutException} when a condition was not fulfilled within the specified threshold.
+     */
+    private final boolean ignoreConditionTimeout;
+
+    /**
      * Instantiates a new condition factory.
      *
      * @param alias                       the alias
@@ -102,10 +107,12 @@ public class ConditionFactory {
      * @param conditionEvaluationListener Determine which exceptions that should ignored
      * @param executorLifecycle           The executor service and the lifecycle of the executor service that'll be used to evaluate the condition during polling
      * @param failFastCondition           If this condition if ever false, indicates our condition will never be true.
+     * @param ignoreConditionTimeout      Whether to throw a {@link ConditionTimeoutException} when a condition was not fulfilled within the specified threshold
      */
     public ConditionFactory(final String alias, WaitConstraint timeoutConstraint, PollInterval pollInterval, Duration pollDelay,
                             boolean catchUncaughtExceptions, ExceptionIgnorer exceptionsIgnorer,
-                            ConditionEvaluationListener conditionEvaluationListener, ExecutorLifecycle executorLifecycle, final FailFastCondition failFastCondition) {
+                            ConditionEvaluationListener conditionEvaluationListener, ExecutorLifecycle executorLifecycle, final FailFastCondition failFastCondition,
+                            boolean ignoreConditionTimeout) {
         if (pollInterval == null) {
             throw new IllegalArgumentException("pollInterval cannot be null");
         }
@@ -122,6 +129,7 @@ public class ConditionFactory {
         this.exceptionsIgnorer = exceptionsIgnorer;
         this.executorLifecycle = executorLifecycle;
         this.failFastCondition = failFastCondition;
+        this.ignoreConditionTimeout = ignoreConditionTimeout;
     }
 
     /**
@@ -132,7 +140,7 @@ public class ConditionFactory {
      */
     public ConditionFactory conditionEvaluationListener(ConditionEvaluationListener conditionEvaluationListener) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -142,7 +150,7 @@ public class ConditionFactory {
      */
     public ConditionFactory logging() {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, new ConditionEvaluationLogger(), executorLifecycle, failFastCondition);
+                exceptionsIgnorer, new ConditionEvaluationLogger(), executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -152,7 +160,7 @@ public class ConditionFactory {
      */
     public ConditionFactory logging(Consumer<String> logPrinter) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, new ConditionEvaluationLogger(logPrinter), executorLifecycle, failFastCondition);
+                exceptionsIgnorer, new ConditionEvaluationLogger(logPrinter), executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -173,7 +181,7 @@ public class ConditionFactory {
      */
     public ConditionFactory atMost(Duration timeout) {
         return new ConditionFactory(alias, timeoutConstraint.withMaxWaitTime(timeout), pollInterval, pollDelay,
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -184,7 +192,7 @@ public class ConditionFactory {
      */
     public ConditionFactory during(Duration timeout) {
         return new ConditionFactory(alias, timeoutConstraint.withHoldPredicateTime(timeout), pollInterval, pollDelay,
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -207,7 +215,7 @@ public class ConditionFactory {
      */
     public ConditionFactory alias(String alias) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay,
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -218,7 +226,7 @@ public class ConditionFactory {
      */
     public ConditionFactory atLeast(Duration timeout) {
         return new ConditionFactory(alias, timeoutConstraint.withMinWaitTime(timeout), pollInterval, pollDelay,
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -265,7 +273,7 @@ public class ConditionFactory {
      */
     public ConditionFactory forever() {
         return new ConditionFactory(alias, AtMostWaitConstraint.FOREVER, pollInterval, pollDelay,
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -284,7 +292,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollInterval(Duration pollInterval) {
         return new ConditionFactory(alias, timeoutConstraint, new FixedPollInterval(pollInterval), pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -309,7 +317,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollDelay(long delay, TimeUnit unit) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, DurationFactory.of(delay, unit),
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -325,7 +333,7 @@ public class ConditionFactory {
             throw new IllegalArgumentException("pollDelay cannot be null");
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -358,12 +366,12 @@ public class ConditionFactory {
     public ConditionFactory pollInterval(long pollInterval, TimeUnit unit) {
         PollInterval fixedPollInterval = new FixedPollInterval(DurationFactory.of(pollInterval, unit));
         return new ConditionFactory(alias, timeoutConstraint, fixedPollInterval, definePollDelay(pollDelay, fixedPollInterval),
-                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                catchUncaughtExceptions, exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     public ConditionFactory pollInterval(PollInterval pollInterval) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, definePollDelay(pollDelay, pollInterval), catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -376,7 +384,7 @@ public class ConditionFactory {
      */
     public ConditionFactory catchUncaughtExceptions() {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, true, exceptionsIgnorer,
-                conditionEvaluationListener, executorLifecycle, failFastCondition);
+                conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -395,7 +403,7 @@ public class ConditionFactory {
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
                 new PredicateExceptionIgnorer(e -> exceptionType.isAssignableFrom(e.getClass())),
-                conditionEvaluationListener, executorLifecycle, failFastCondition);
+                conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -413,7 +421,7 @@ public class ConditionFactory {
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
                 new PredicateExceptionIgnorer(e -> e.getClass().equals(exceptionType)),
-                conditionEvaluationListener, executorLifecycle, failFastCondition);
+                conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -448,7 +456,7 @@ public class ConditionFactory {
      */
     public ConditionFactory ignoreExceptionsMatching(Matcher<? super Throwable> matcher) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                new HamcrestExceptionIgnorer(matcher), conditionEvaluationListener, executorLifecycle, failFastCondition);
+                new HamcrestExceptionIgnorer(matcher), conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -460,7 +468,7 @@ public class ConditionFactory {
      */
     public ConditionFactory ignoreExceptionsMatching(Predicate<? super Throwable> predicate) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                new PredicateExceptionIgnorer(predicate), conditionEvaluationListener, executorLifecycle, failFastCondition);
+                new PredicateExceptionIgnorer(predicate), conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -485,7 +493,7 @@ public class ConditionFactory {
      */
     public ConditionFactory await(String alias) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -536,7 +544,7 @@ public class ConditionFactory {
      */
     public ConditionFactory dontCatchUncaughtExceptions() {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, false,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -553,7 +561,7 @@ public class ConditionFactory {
             throw new IllegalArgumentException("Poll executor service cannot be an instance of " + ScheduledExecutorService.class.getName());
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, false,
-                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withoutCleanup(executorService), failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withoutCleanup(executorService), failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -566,7 +574,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollThread(final Function<Runnable, Thread> threadSupplier) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, false,
-                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withNormalCleanupBehavior(() -> InternalExecutorServiceFactory.create(threadSupplier)), failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withNormalCleanupBehavior(() -> InternalExecutorServiceFactory.create(threadSupplier)), failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -587,7 +595,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollInSameThread() {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, false,
-                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withNormalCleanupBehavior(InternalExecutorServiceFactory::sameThreadExecutorService), failFastCondition);
+                exceptionsIgnorer, conditionEvaluationListener, ExecutorLifecycle.withNormalCleanupBehavior(InternalExecutorServiceFactory::sameThreadExecutorService), failFastCondition, ignoreConditionTimeout);
     }
 
     /**
@@ -604,7 +612,7 @@ public class ConditionFactory {
             throw new IllegalArgumentException("failFastCondition cannot be null");
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new CallableFailFastCondition(null, failFastCondition));
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new CallableFailFastCondition(null, failFastCondition), ignoreConditionTimeout);
     }
 
     /**
@@ -623,7 +631,7 @@ public class ConditionFactory {
         }
 
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new CallableFailFastCondition(failFastFailureReason, failFastCondition));
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new CallableFailFastCondition(failFastFailureReason, failFastCondition), ignoreConditionTimeout);
     }
 
     /**
@@ -668,7 +676,33 @@ public class ConditionFactory {
             throw new IllegalArgumentException("failFastAssertion cannot be null");
         }
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new FailFastAssertion(failFastFailureReason, failFastAssertion));
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, new FailFastAssertion(failFastFailureReason, failFastAssertion), ignoreConditionTimeout);
+    }
+
+    /**
+     * Instruct Awaitility to not throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold.
+     * Default should be <code>false</code> (exception is thrown).
+     *
+     * @return the condition factory
+     * @since 4.4.0
+     */
+    public ConditionFactory ignoreConditionTimeout() {
+        return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, true);
+    }
+
+    /**
+     * Instruct Awaitility to throw a {@link ConditionTimeoutException}
+     * when a condition was not fulfilled within the specified threshold.
+     * This should be the default behavior.
+     *
+     * @return the condition factory
+     * @since 4.4.0
+     */
+    public ConditionFactory dontIgnoreConditionTimeout() {
+        return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
+                exceptionsIgnorer, conditionEvaluationListener, executorLifecycle, failFastCondition, false);
     }
 
     /**
@@ -1153,7 +1187,7 @@ public class ConditionFactory {
         }
 
         return new ConditionSettings(alias, catchUncaughtExceptions, timeoutConstraint, pollInterval, actualPollDelay,
-                conditionEvaluationListener, exceptionsIgnorer, executorLifecycle, failFastCondition);
+                conditionEvaluationListener, exceptionsIgnorer, executorLifecycle, failFastCondition, ignoreConditionTimeout);
     }
 
     private <T> T until(Condition<T> condition) {

--- a/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionSettings.java
@@ -31,6 +31,7 @@ public class ConditionSettings {
     private final ConditionEvaluationListener conditionEvaluationListener;
     private final ExecutorLifecycle executorLifecycle;
     private final FailFastCondition failFastCondition;
+    private final boolean ignoreConditionTimeout;
 
     /**
      * <p>Constructor for ConditionSettings.</p>
@@ -43,10 +44,12 @@ public class ConditionSettings {
      * @param ignoreExceptions            a {@link ExceptionIgnorer} object.
      * @param executorLifecycle           Responsible for performing executor service cleanup after each condition evaluation round
      * @param failFastCondition           a Callable that if returns true, fails the test immediately
+     * @param ignoreConditionTimeout      whether to throw a {@link ConditionTimeoutException} when a condition was not fulfilled within the specified threshold.
      */
     ConditionSettings(String alias, boolean catchUncaughtExceptions, WaitConstraint waitConstraint,
                       PollInterval pollInterval, Duration pollDelay, ConditionEvaluationListener conditionEvaluationListener,
-                      ExceptionIgnorer ignoreExceptions, ExecutorLifecycle executorLifecycle, final FailFastCondition failFastCondition) {
+                      ExceptionIgnorer ignoreExceptions, ExecutorLifecycle executorLifecycle, final FailFastCondition failFastCondition,
+                      boolean ignoreConditionTimeout) {
         if (waitConstraint == null) {
             throw new IllegalArgumentException("You must specify a maximum waiting time (was null).");
         }
@@ -62,6 +65,7 @@ public class ConditionSettings {
         this.conditionEvaluationListener = conditionEvaluationListener;
         this.ignoreExceptions = ignoreExceptions;
         this.failFastCondition = failFastCondition;
+        this.ignoreConditionTimeout = ignoreConditionTimeout;
     }
 
     /**
@@ -164,5 +168,12 @@ public class ConditionSettings {
      */
     public FailFastCondition getFailFastCondition() {
         return this.failFastCondition;
+    }
+
+    /**
+     * @return whether to throw a {@link ConditionTimeoutException} when a condition was not fulfilled within the specified threshold.
+     */
+    public boolean shouldIgnoreConditionTimeout() {
+        return ignoreConditionTimeout;
     }
 }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -520,6 +520,50 @@ public class AwaitilityTest {
         Awaitility.await().atMost(timeoutMinutes, TimeUnit.MINUTES).until(() -> true);
     }
 
+    @Test(timeout = 2000)
+    public void ignoredConditionTimeoutShouldPreventConditionTimeoutExceptionWhenDoneLaterThanAtMostConstraint() {
+        await().ignoreConditionTimeout().atMost(200, TimeUnit.MILLISECONDS).until(() -> false);
+    }
+
+    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
+    public void unIgnoredConditionTimeoutShouldNotPreventConditionTimeoutExceptionWhenDoneLaterThanAtMostConstraint() {
+        await().dontIgnoreConditionTimeout().atMost(200, TimeUnit.MILLISECONDS).until(() -> false);
+    }
+
+    @Test(timeout = 2000)
+    public void ignoredConditionTimeoutByDefaultShouldPreventConditionTimeoutExceptionWhenDoneLaterThanAtMostConstraint() {
+        ignoreConditionTimeoutByDefault();
+        await().atMost(200, TimeUnit.MILLISECONDS).until(() -> false);
+    }
+
+    @Test(timeout = 2000, expected = ConditionTimeoutException.class)
+    public void unIgnoredConditionTimeoutByDefaultShouldNotPreventConditionTimeoutExceptionWhenDoneLaterThanAtMostConstraint() {
+        doNotIgnoreConditionTimeoutByDefault();
+        await().atMost(200, TimeUnit.MILLISECONDS).until(() -> false);
+    }
+
+    @Test(timeout = 3000)
+    public void ignoredConditionTimeoutShouldPreventConditionTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
+        await().ignoreConditionTimeout().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(() -> true);
+    }
+
+    @Test(timeout = 3000, expected = ConditionTimeoutException.class)
+    public void unIgnoredConditionTimeoutShouldNotPreventConditionTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
+        await().dontIgnoreConditionTimeout().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(() -> true);
+    }
+
+    @Test(timeout = 3000)
+    public void ignoredConditionTimeoutByDefaultShouldPreventConditionTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
+        ignoreConditionTimeoutByDefault();
+        await().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(() -> true);
+    }
+
+    @Test(timeout = 3000, expected = ConditionTimeoutException.class)
+    public void unIgnoredConditionTimeoutByDefaultShouldNotPreventConditionTimeoutExceptionWhenDoneEarlierThanAtLeastConstraint() {
+        doNotIgnoreConditionTimeoutByDefault();
+        await().atLeast(1, SECONDS).and().atMost(2, SECONDS).until(() -> true);
+    }
+
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {
         return new FakeRepositoryEqualsOne(fakeRepository);
     }


### PR DESCRIPTION
Make it possible to instruct Awaitility to throw or not to throw a `ConditionTimeoutException` when a condition was not fulfilled within the specified threshold. The default behavior is kept as-is which is throwing an exception.

Fixes gh-48