### PR TITLE
remove hamcrest from transitive dependencies

### DIFF
--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -26,9 +26,9 @@
     <description>Simplifies Awaitility usage from Groovy</description>
 
     <properties>
-        <groovy.version>4.0.19</groovy.version>
-        <spock.version>2.4-M2-groovy-4.0</spock.version>
-        <gmaven.version>1.7.1</gmaven.version>
+        <groovy.version>4.0.30</groovy.version>
+        <spock.version>2.4-groovy-4.0</spock.version>
+
     </properties>
 
     <dependencies>
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>${gmaven.version}</version>
+                <version>${gmavenplus-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/awaitility-kotlin/pom.xml
+++ b/awaitility-kotlin/pom.xml
@@ -26,8 +26,8 @@
     <description>Simplifies Awaitility usage from Kotlin</description>
 
     <properties>
-        <kotlin.version>2.1.10</kotlin.version>
-        <dokka.version>2.0.0</dokka.version>
+        <kotlin.version>2.3.0</kotlin.version>
+        <dokka.version>2.1.0</dokka.version>
     </properties>
 
     <dependencies>
@@ -40,6 +40,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- Test -->
         <dependency>

--- a/awaitility-kotlin/src/main/kotlin/org/awaitility/kotlin/AwaitilityKt.kt
+++ b/awaitility-kotlin/src/main/kotlin/org/awaitility/kotlin/AwaitilityKt.kt
@@ -10,9 +10,7 @@ import org.awaitility.Awaitility
 import org.awaitility.core.ConditionEvaluationListener
 import org.awaitility.core.ConditionFactory
 import org.awaitility.pollinterval.PollInterval
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers.not
-import org.hamcrest.Matchers.nullValue
+import org.awaitility.core.Matcher
 import java.time.Duration
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
@@ -108,7 +106,7 @@ infix fun <T> ConditionFactory.untilCallTo(fn: () -> T) = AwaitilityKtUntilFunCo
  *
  * @since 3.1.4
  */
-infix fun <T> ConditionFactory.untilNotNull(fn: () -> T?) = (until(fn, not(nullValue())))!!
+infix fun <T> ConditionFactory.untilNotNull(fn: () -> T?) = until(fn, java.util.function.Predicate { it != null })!!
 
 /**
  * An extension function to `ConditionFactory` that allows you do write conditions such as:
@@ -122,7 +120,7 @@ infix fun <T> ConditionFactory.untilNotNull(fn: () -> T?) = (until(fn, not(nullV
  * @since 3.1.5
  */
 infix fun <T> ConditionFactory.untilNull(fn: () -> T?) {
-    until(fn, nullValue())
+    until(fn, java.util.function.Predicate { it == null })
 }
 
 /**
@@ -337,18 +335,18 @@ infix fun ConditionFactory.ignoreExceptionsInstanceOf(exceptionType: KClass<out 
 infix fun ConditionFactory.ignoreException(exceptionType: KClass<out Throwable>): ConditionFactory = ignoreException(exceptionType.javaObjectType)
 
 /**
- * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied Hamcrest matcher.
+ * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied matcher.
  * Exceptions will be treated as evaluating to `false`. This is useful in situations where the evaluated
  * conditions may temporarily throw exceptions.
  *
- * @param matcher The Hamcrest matcher
+ * @param matcher The matcher
  * @return the condition factory.
  * @since 3.1.2
  */
 infix fun ConditionFactory.ignoreExceptionsMatching(matcher: Matcher<in Throwable>): ConditionFactory = ignoreExceptionsMatching(matcher)
 
 /**
- * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied Hamcrest matcher.
+ * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied matcher.
  * Exceptions will be treated as evaluating to `false`. This is useful in situations where the evaluated
  * conditions may temporarily throw exceptions.
  *
@@ -356,7 +354,7 @@ infix fun ConditionFactory.ignoreExceptionsMatching(matcher: Matcher<in Throwabl
  * @return the condition factory.
  * @since 3.1.2
  */
-infix fun ConditionFactory.ignoreExceptionsMatching(matcher: (Throwable) -> Boolean): ConditionFactory = ignoreExceptionsMatching(matcher)
+infix fun ConditionFactory.ignoreExceptionsMatching(matcher: (Throwable) -> Boolean): ConditionFactory = ignoreExceptionsMatching(java.util.function.Predicate<Throwable> { matcher(it) })
 
 /**
  * Specify the executor service whose threads will be used to evaluate the poll condition in Awaitility.
@@ -400,7 +398,7 @@ infix fun ConditionFactory.untilTrue(atomicBoolean: AtomicBoolean) = untilTrue(a
 infix fun ConditionFactory.untilFalse(atomicBoolean: AtomicBoolean) = untilFalse(atomicBoolean)
 
 /**
- * Handle condition evaluation results each time evaluation of a condition occurs. Works only with a Hamcrest matcher-based condition.
+ * Handle condition evaluation results each time evaluation of a condition occurs. Works only with a matcher-based condition.
  *
  * @param conditionEvaluationListener the condition evaluation listener
  * @return the condition factory

--- a/awaitility-kotlin/src/test/kotlin/org/awaitility/kotlin/KotlinTest.kt
+++ b/awaitility-kotlin/src/test/kotlin/org/awaitility/kotlin/KotlinTest.kt
@@ -26,7 +26,9 @@ import org.awaitility.classes.FakeRepositoryImpl
 import org.awaitility.core.ConditionEvaluationListener
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.pollinterval.FibonacciPollInterval.fibonacci
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.endsWith
+import org.hamcrest.Matchers.startsWith
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -144,9 +146,9 @@ class KotlinTest {
             atomicReference.set("world")
         }.start()
 
-        await.untilAtomic(atomicReference) { string ->
+        await.untilAtomic(atomicReference, java.util.function.Consumer { string ->
             assertThat(string).isEqualTo("world")
-        }
+        })
     }
 
     @Test
@@ -169,7 +171,7 @@ class KotlinTest {
             await() atMost Duration.ofSeconds(1) untilCallTo { fakeRepository.value } matches { it == 2 }
         }
 
-        assertThat(throwable).isExactlyInstanceOf(ConditionTimeoutException::class.java).hasMessageEndingWith("expected the predicate to return <true> but it returned <false> for input of <1> within 1 seconds.")
+        assertThat(throwable).isExactlyInstanceOf(ConditionTimeoutException::class.java).hasMessageEndingWith("returned a value not matching the predicate: <1> within 1 seconds.")
     }
 
     @Test

--- a/awaitility-osgi-test/pom.xml
+++ b/awaitility-osgi-test/pom.xml
@@ -9,7 +9,6 @@
 
     <properties>
         <animal.sniffer.skip>true</animal.sniffer.skip>
-        <pax-exam.version>4.13.4</pax-exam.version>
     </properties>
 
     <dependencies>
@@ -17,6 +16,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -51,13 +55,13 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>5.6.4</version>
+            <version>${felix.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>
             <artifactId>pax-swissbox-framework</artifactId>
-            <version>1.8.3</version>
+            <version>${pax-swissbox.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -73,7 +77,7 @@
 			<plugin>
 				<groupId>org.apache.servicemix.tooling</groupId>
 				<artifactId>depends-maven-plugin</artifactId>
-				<version>1.3.1</version>
+				<version>${depends-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>generate-depends-file</id>
@@ -86,7 +90,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
 				<configuration>
 					<forkCount>1</forkCount>
 					<reuseForks>false</reuseForks>

--- a/awaitility-osgi-test/src/test/java/org/awaitility/test/osgi/AwaitilityTest.java
+++ b/awaitility-osgi-test/src/test/java/org/awaitility/test/osgi/AwaitilityTest.java
@@ -44,11 +44,10 @@ public class AwaitilityTest {
                         systemProperty(EXAM_FAIL_ON_UNRESOLVED_KEY).value("true"),
                         systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("INFO"),
 
-                        /* Hamcrest & JUnit bundles */
+                        /* JUnit bundles */
                         junitBundles(),
 
                         /* Deps */
-                        mavenBundle().groupId("org.hamcrest").artifactId("hamcrest").versionAsInProject(),
                         mavenBundle("org.awaitility", "awaitility").versionAsInProject(),
                         // CoreOptions.vmOption("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")
                 };

--- a/awaitility-scala/pom.xml
+++ b/awaitility-scala/pom.xml
@@ -26,7 +26,7 @@
     <description>Simplifies Awaitility usage from Scala</description>
 
     <properties>
-        <scala.version>2.13.13</scala.version>
+        <scala.version>2.13.18</scala.version>
     </properties>
 
     <dependencies>
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -56,7 +57,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>${scala-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -88,7 +89,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -119,7 +120,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.10</version>
+                <version>${maven-eclipse-plugin.version}</version>
                 <configuration>
                     <downloadSources>true</downloadSources>
                     <buildcommands>

--- a/awaitility-scala/src/test/scala/org/awaitility/scala/AwaitilitySupportTest.scala
+++ b/awaitility-scala/src/test/scala/org/awaitility/scala/AwaitilitySupportTest.scala
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import org.awaitility.Awaitility._
 import org.awaitility.core.ConditionTimeoutException
+import org.awaitility.core.{Matchers => AwaitilityMatchers}
 import org.hamcrest.CoreMatchers.is
 import org.hamcrest.Matchers.{containsString, endsWith, startsWith}
 import org.hamcrest.{CoreMatchers, Matchers}
@@ -61,15 +62,15 @@ class AwaitilitySupportTest extends AwaitilitySupport {
     val c1 = new Counter()
     val c2 = new Counter()
 
-    await until (c1.count() + c2.count(),  is(6))
-    await until (isDone(), is(java.lang.Boolean.TRUE))
-    await until (isDone, Matchers is java.lang.Boolean.TRUE )
+    await until (c1.count() + c2.count(),  AwaitilityMatchers.is(6))
+    await until (isDone(), AwaitilityMatchers.is(java.lang.Boolean.TRUE))
+    await until (isDone, AwaitilityMatchers.is(java.lang.Boolean.TRUE))
   }
 
   @Test
   def awaitWithAliasSupplierAndMatcher(): Unit = {
     try {
-      await("scala") atMost(500, MILLISECONDS) until (2 == 1, is(java.lang.Boolean.TRUE))
+      await("scala") atMost(500, MILLISECONDS) until (2 == 1, AwaitilityMatchers.is(java.lang.Boolean.TRUE))
       fail("Expected timeout exception")
     } catch {
         case e : ConditionTimeoutException =>

--- a/awaitility/pom.xml
+++ b/awaitility/pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.9</version>
+                <version>${maven-bundle-plugin.version}</version>
                 <configuration>
                     <obrRepository>NONE</obrRepository>
                     <instructions>
@@ -58,11 +58,6 @@
                             <goal>jar</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -71,6 +66,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/awaitility/src/main/java/org/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/org/awaitility/Awaitility.java
@@ -17,12 +17,23 @@ package org.awaitility;
 
 import org.awaitility.constraint.AtMostWaitConstraint;
 import org.awaitility.constraint.WaitConstraint;
-import org.awaitility.core.*;
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.ConditionEvaluationLogger;
+import org.awaitility.core.ConditionFactory;
+import org.awaitility.core.DurationFactory;
+import org.awaitility.core.ExceptionIgnorer;
+import org.awaitility.core.ExecutorLifecycle;
+import org.awaitility.core.FailFastCondition;
 import org.awaitility.core.FailFastCondition.CallableFailFastCondition;
 import org.awaitility.core.FailFastCondition.CallableFailFastCondition.FailFastAssertion;
+import org.awaitility.core.FieldSupplierBuilder;
+import org.awaitility.core.InternalExecutorServiceFactory;
+import org.awaitility.core.Matcher;
+import org.awaitility.core.MatcherExceptionIgnorer;
+import org.awaitility.core.PredicateExceptionIgnorer;
+import org.awaitility.core.ThrowingRunnable;
 import org.awaitility.pollinterval.FixedPollInterval;
 import org.awaitility.pollinterval.PollInterval;
-import org.hamcrest.Matcher;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -88,7 +99,7 @@ import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
  * It may also be useful to import these methods:
  * <ul>
  * <li>java.util.concurrent.TimeUnit.*</li>
- * <li>org.hamcrest.Matchers.*</li>
+ * <li>org.awaitility.core.Matcher.*</li>
  * <li>org.junit.Assert.*</li>
  * </ul>
  * <p>&nbsp;</p>
@@ -209,7 +220,7 @@ public class Awaitility {
      * upon an exception matching the supplied exception type, unless it times out.
      */
     public static void ignoreExceptionsByDefaultMatching(Matcher<? super Throwable> matcher) {
-        defaultExceptionIgnorer = new HamcrestExceptionIgnorer(matcher);
+        defaultExceptionIgnorer = new MatcherExceptionIgnorer(matcher);
     }
 
     /**
@@ -470,7 +481,7 @@ public class Awaitility {
     /**
      * Sets the default condition evaluation listener that all await statements will use.
      *
-     * @param defaultConditionEvaluationListener handles condition evaluation each time evaluation of a condition occurs. Works only with Hamcrest matcher-based conditions.
+     * @param defaultConditionEvaluationListener handles condition evaluation each time evaluation of a condition occurs. Works only with matcher-based conditions.
      */
     public static void setDefaultConditionEvaluationListener(ConditionEvaluationListener defaultConditionEvaluationListener) {
         Awaitility.defaultConditionEvaluationListener = defaultConditionEvaluationListener;

--- a/awaitility/src/main/java/org/awaitility/core/AbstractMatcherCondition.java
+++ b/awaitility/src/main/java/org/awaitility/core/AbstractMatcherCondition.java
@@ -15,13 +15,9 @@
  */
 package org.awaitility.core;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
-
 import java.util.concurrent.Callable;
 
-public abstract class AbstractHamcrestCondition<T> implements Condition<T> {
+public abstract class AbstractMatcherCondition<T> implements Condition<T> {
 
     private ConditionAwaiter conditionAwaiter;
 
@@ -29,13 +25,13 @@ public abstract class AbstractHamcrestCondition<T> implements Condition<T> {
     private final ConditionEvaluationHandler<T> conditionEvaluationHandler;
 
     /**
-     * <p>Constructor for AbstractHamcrestCondition.</p>
+     * <p>Constructor for AbstractMatcherCondition.</p>
      *
      * @param supplier a {@link java.util.concurrent.Callable} object.
-     * @param matcher  a {@link org.hamcrest.Matcher} object.
+     * @param matcher  a {@link org.awaitility.core.Matcher} object.
      * @param settings a {@link org.awaitility.core.ConditionSettings} object.
      */
-    protected AbstractHamcrestCondition(final Callable<T> supplier, final Matcher<? super T> matcher, final ConditionSettings settings) {
+    protected AbstractMatcherCondition(final Callable<T> supplier, final Matcher<? super T> matcher, final ConditionSettings settings) {
         if (supplier == null) {
             throw new IllegalArgumentException("You must specify a supplier (was null).");
         }
@@ -65,16 +61,12 @@ public abstract class AbstractHamcrestCondition<T> implements Condition<T> {
 
 
     private String getMatchMessage(Callable<T> supplier, Matcher<? super T> matcher) {
-        return String.format("%s reached its end value of %s", getCallableDescription(supplier), HamcrestToStringFilter.filter(matcher));
+        return String.format("%s reached its end value of %s", getCallableDescription(supplier), matcher.describe());
     }
 
     private String getMismatchMessage(Callable<T> supplier, Matcher<? super T> matcher) {
-        Description mismatchDescription = new StringDescription();
-        matcher.describeMismatch(lastResult, mismatchDescription);
-        if (mismatchDescription.toString() != null && mismatchDescription.toString().isEmpty()) {
-            mismatchDescription.appendText("was ").appendValue(lastResult);
-        }
-        return String.format("%s expected %s but %s", getCallableDescription(supplier), HamcrestToStringFilter.filter(matcher), mismatchDescription);
+        String mismatchDescription = matcher.describeMismatch(lastResult);
+        return String.format("%s expected %s but %s", getCallableDescription(supplier), matcher.describe(), mismatchDescription);
     }
 
     /**

--- a/awaitility/src/main/java/org/awaitility/core/AssertionCondition.java
+++ b/awaitility/src/main/java/org/awaitility/core/AssertionCondition.java
@@ -75,7 +75,7 @@ public class AssertionCondition implements Condition<Void> {
 
     private String getMismatchMessage(ThrowingRunnable supplier, String exceptionMessage, String conditionAlias, boolean includeAliasIfDefined) {
         if (exceptionMessage != null && exceptionMessage.endsWith(".")) {
-            // Remove the "." of the Hamcrest match description since Awaitility adds more
+            // Remove the "." of the match description since Awaitility adds more
             exceptionMessage = exceptionMessage.substring(0, exceptionMessage.length() - 1);
         }
         return generateDescriptionPrefix(supplier, conditionAlias, includeAliasIfDefined) + " " + exceptionMessage;

--- a/awaitility/src/main/java/org/awaitility/core/CallableMatcherCondition.java
+++ b/awaitility/src/main/java/org/awaitility/core/CallableMatcherCondition.java
@@ -16,7 +16,6 @@
 package org.awaitility.core;
 
 import org.awaitility.reflect.WhiteboxImpl;
-import org.hamcrest.Matcher;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -26,17 +25,17 @@ import java.util.concurrent.Callable;
 import static org.awaitility.core.LambdaErrorMessageGenerator.generateLambdaErrorMessagePrefix;
 import static org.awaitility.core.LambdaErrorMessageGenerator.isLambdaClass;
 
-class CallableHamcrestCondition<T> extends AbstractHamcrestCondition<T> {
+class CallableMatcherCondition<T> extends AbstractMatcherCondition<T> {
 
 
     /**
-     * <p>Constructor for CallableHamcrestCondition.</p>
+     * <p>Constructor for CallableMatcherCondition.</p>
      *
      * @param supplier a {@link java.util.concurrent.Callable} object.
-     * @param matcher a {@link org.hamcrest.Matcher} object.
+     * @param matcher a {@link org.awaitility.core.Matcher} object.
      * @param settings a {@link org.awaitility.core.ConditionSettings} object.
      */
-    public CallableHamcrestCondition(final Callable<T> supplier, final Matcher<? super T> matcher, ConditionSettings settings) {
+    public CallableMatcherCondition(final Callable<T> supplier, final Matcher<? super T> matcher, ConditionSettings settings) {
         super(supplier, matcher, settings);
     }
 

--- a/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionAwaiter.java
@@ -22,7 +22,11 @@ import org.awaitility.core.FailFastCondition.CallableFailFastCondition.FailFastA
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
@@ -127,7 +131,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
             lastResult = new ConditionEvaluationResult(false, e, null);
         } finally {
             if (currentConditionEvaluation != null) {
-                // Cancelling future in order to avoid race-condition with last result for Hamcrest matchers
+                // Cancelling future in order to avoid race-condition with last result for matchers
                 // See https://github.com/awaitility/awaitility/issues/109
                 currentConditionEvaluation.cancel(true);
             }

--- a/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationHandler.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionEvaluationHandler.java
@@ -15,8 +15,6 @@
  */
 package org.awaitility.core;
 
-import org.hamcrest.Matcher;
-
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Consumer;
@@ -29,11 +27,11 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  */
 class ConditionEvaluationHandler<T> {
 
-    private final Matcher<? super T> matcher;
+    private final Object matcher;
     private final ConditionSettings settings;
     private final StopWatch watch;
 
-    ConditionEvaluationHandler(Matcher<? super T> matcher, ConditionSettings settings) {
+    ConditionEvaluationHandler(Object matcher, ConditionSettings settings) {
         this.matcher = matcher;
         this.settings = settings;
         watch = new StopWatch();

--- a/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/org/awaitility/core/ConditionFactory.java
@@ -21,24 +21,25 @@ import org.awaitility.core.FailFastCondition.CallableFailFastCondition;
 import org.awaitility.core.FailFastCondition.CallableFailFastCondition.FailFastAssertion;
 import org.awaitility.pollinterval.FixedPollInterval;
 import org.awaitility.pollinterval.PollInterval;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.awaitility.core.ForeverDuration.isForever;
 import static org.awaitility.core.TemporalDuration.formatAsString;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.is;
 
 /**
  * A factory for creating {@link org.awaitility.core.Condition} objects. It's not recommended instantiating this class directly.
@@ -125,7 +126,7 @@ public class ConditionFactory {
     }
 
     /**
-     * Handle condition evaluation results each time evaluation of a condition occurs. Works only with a Hamcrest matcher-based condition.
+     * Handle condition evaluation results each time evaluation of a condition occurs. Works only with a matcher-based condition.
      *
      * @param conditionEvaluationListener the condition evaluation listener
      * @return the condition factory
@@ -425,7 +426,7 @@ public class ConditionFactory {
      * @return the condition factory.
      */
     public ConditionFactory ignoreExceptions() {
-        return ignoreExceptionsMatching(e -> true);
+        return ignoreExceptionsMatching((Predicate<Throwable>) e -> true);
     }
 
     /**
@@ -436,11 +437,11 @@ public class ConditionFactory {
      * @return the condition factory.
      */
     public ConditionFactory ignoreNoExceptions() {
-        return ignoreExceptionsMatching(e -> false);
+        return ignoreExceptionsMatching((Predicate<Throwable>) e -> false);
     }
 
     /**
-     * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied Hamcrest matcher.
+     * Instruct Awaitility to ignore exceptions that occur during evaluation and matches the supplied matcher.
      * Exceptions will be treated as evaluating to
      * <code>false</code>. This is useful in situations where the evaluated conditions may temporarily throw exceptions.
      *
@@ -448,7 +449,7 @@ public class ConditionFactory {
      */
     public ConditionFactory ignoreExceptionsMatching(Matcher<? super Throwable> matcher) {
         return new ConditionFactory(alias, timeoutConstraint, pollInterval, pollDelay, catchUncaughtExceptions,
-                new HamcrestExceptionIgnorer(matcher), conditionEvaluationListener, executorLifecycle, failFastCondition);
+                new MatcherExceptionIgnorer(matcher), conditionEvaluationListener, executorLifecycle, failFastCondition);
     }
 
     /**
@@ -673,7 +674,7 @@ public class ConditionFactory {
 
     /**
      * Await until a {@link java.util.concurrent.Callable} supplies a value matching the specified
-     * {@link org.hamcrest.Matcher}. E.g.
+     * {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().until(numberOfPersons(), is(greaterThan(2)));
@@ -703,13 +704,12 @@ public class ConditionFactory {
      * @param <T>      the generic type
      * @param supplier the supplier that is responsible for getting the value that
      *                 should be matched.
-     * @param matcher  the matcher The hamcrest matcher that checks whether the
-     *                 condition is fulfilled.
+     * @param matcher  the matcher
      * @return a T object.
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public <T> T until(final Callable<T> supplier, final Matcher<? super T> matcher) {
-        return until(new CallableHamcrestCondition<>(supplier, matcher, generateConditionSettings()));
+        return until(new CallableMatcherCondition<>(supplier, matcher, generateConditionSettings()));
     }
 
     /**
@@ -726,22 +726,7 @@ public class ConditionFactory {
      * @since 3.1.1
      */
     public <T> T until(final Callable<T> supplier, final Predicate<? super T> predicate) {
-        return until(supplier, new TypeSafeMatcher<T>() {
-            @Override
-            protected void describeMismatchSafely(T item, Description description) {
-                description.appendText("it returned <false> for input of ").appendValue(item);
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("the predicate to return <true>");
-            }
-
-            @Override
-            protected boolean matchesSafely(T item) {
-                return predicate.test(item);
-            }
-        });
+        return new PredicateCondition<>(supplier, predicate, generateConditionSettings()).await();
     }
 
     /**
@@ -821,20 +806,19 @@ public class ConditionFactory {
 
     /**
      * Await until a Atomic variable has a value matching the specified
-     * {@link org.hamcrest.Matcher}. E.g.
+     * {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAtomic(myAtomic, is(greaterThan(2)));
      * </pre>
      *
      * @param atomic  the atomic variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the
-     *                condition is fulfilled.
+     * @param matcher the matcher
      * @return a {@link java.lang.Integer} object.
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public Integer untilAtomic(final AtomicInteger atomic, final Matcher<? super Integer> matcher) {
-        return until(new CallableHamcrestCondition<>(atomic::get, matcher, generateConditionSettings()));
+        return until(new CallableMatcherCondition<>(atomic::get, matcher, generateConditionSettings()));
     }
 
     /**
@@ -855,20 +839,19 @@ public class ConditionFactory {
 
     /**
      * Await until a Atomic variable has a value matching the specified
-     * {@link org.hamcrest.Matcher}. E.g.
+     * {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAtomic(myAtomic, is(greaterThan(2)));
      * </pre>
      *
      * @param atomic  the atomic variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the
-     *                condition is fulfilled.
+     * @param matcher the matcher
      * @return a {@link java.lang.Long} object.
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public Long untilAtomic(final AtomicLong atomic, final Matcher<? super Long> matcher) {
-        return until(new CallableHamcrestCondition<>(atomic::get, matcher, generateConditionSettings()));
+        return until(new CallableMatcherCondition<>(atomic::get, matcher, generateConditionSettings()));
     }
 
     /**
@@ -889,19 +872,18 @@ public class ConditionFactory {
 
     /**
      * Await until a Atomic variable has a value matching the specified
-     * {@link org.hamcrest.Matcher}. E.g.
+     * {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAtomic(myAtomic, is(greaterThan(2)));
      * </pre>
      *
      * @param atomic  the atomic variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the
-     *                condition is fulfilled.
+     * @param matcher the matcher
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilAtomic(final AtomicBoolean atomic, final Matcher<? super Boolean> matcher) {
-        until(new CallableHamcrestCondition<>(atomic::get, matcher, generateConditionSettings()));
+        until(new CallableMatcherCondition<>(atomic::get, matcher, generateConditionSettings()));
     }
 
     /**
@@ -927,7 +909,7 @@ public class ConditionFactory {
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilTrue(final AtomicBoolean atomic) {
-        untilAtomic(atomic, anyOf(is(Boolean.TRUE), is(true)));
+        until(atomic::get, (Predicate<Boolean>) Boolean.TRUE::equals);
     }
 
     /**
@@ -937,22 +919,22 @@ public class ConditionFactory {
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilFalse(final AtomicBoolean atomic) {
-        untilAtomic(atomic, anyOf(is(Boolean.FALSE), is(false)));
+        until(atomic::get, (Predicate<Boolean>) Boolean.FALSE::equals);
     }
 
     /**
-     * Await until a {@link LongAdder} has a value matching the specified {@link org.hamcrest.Matcher}. E.g.
+     * Await until a {@link LongAdder} has a value matching the specified {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAdder(myLongAdder, is(greaterThan(2L)));
      * </pre>
      *
      * @param adder   the {@link LongAdder} variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the condition is fulfilled.
+     * @param matcher the matcher
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilAdder(final LongAdder adder, final Matcher<? super Long> matcher) {
-        until(new CallableHamcrestCondition<>(adder::longValue, matcher, generateConditionSettings()));
+        until(new CallableMatcherCondition<>(adder::longValue, matcher, generateConditionSettings()));
     }
 
     /**
@@ -972,18 +954,18 @@ public class ConditionFactory {
     }
 
     /**
-     * Await until a {@link DoubleAdder} has a value matching the specified {@link org.hamcrest.Matcher}. E.g.
+     * Await until a {@link DoubleAdder} has a value matching the specified {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAdder(myDoubleAdder, is(greaterThan(2.0d)));
      * </pre>
      *
      * @param adder   the {@link DoubleAdder} variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the condition is fulfilled.
+     * @param matcher the matcher
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilAdder(final DoubleAdder adder, final Matcher<? super Double> matcher) {
-        until(new CallableHamcrestCondition<>(adder::doubleValue, matcher, generateConditionSettings()));
+        until(new CallableMatcherCondition<>(adder::doubleValue, matcher, generateConditionSettings()));
     }
 
     /**
@@ -1003,18 +985,18 @@ public class ConditionFactory {
     }
 
     /**
-     * Await until a {@link LongAccumulator} has a value matching the specified {@link org.hamcrest.Matcher}. E.g.
+     * Await until a {@link LongAccumulator} has a value matching the specified {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAccumulator(myLongAccumulator, is(greaterThan(2L)));
      * </pre>
      *
      * @param accumulator the {@link LongAccumulator} variable
-     * @param matcher     the matcher The hamcrest matcher that checks whether the condition is fulfilled.
+     * @param matcher     the matcher
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilAccumulator(final LongAccumulator accumulator, final Matcher<? super Long> matcher) {
-        until(new CallableHamcrestCondition<>(accumulator::longValue, matcher, generateConditionSettings()));
+        until(new CallableMatcherCondition<>(accumulator::longValue, matcher, generateConditionSettings()));
     }
 
     /**
@@ -1034,18 +1016,18 @@ public class ConditionFactory {
     }
 
     /**
-     * Await until a {@link DoubleAccumulator} has a value matching the specified {@link org.hamcrest.Matcher}. E.g.
+     * Await until a {@link DoubleAccumulator} has a value matching the specified {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAccumulator(myDoubleAccumulator, is(greaterThan(2.0d)));
      * </pre>
      *
      * @param accumulator the {@link DoubleAccumulator} variable
-     * @param matcher     the matcher The hamcrest matcher that checks whether the condition is fulfilled.
+     * @param matcher     the matcher
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public void untilAccumulator(final DoubleAccumulator accumulator, final Matcher<? super Double> matcher) {
-        until(new CallableHamcrestCondition<>(accumulator::doubleValue, matcher, generateConditionSettings()));
+        until(new CallableMatcherCondition<>(accumulator::doubleValue, matcher, generateConditionSettings()));
     }
 
     /**
@@ -1066,21 +1048,20 @@ public class ConditionFactory {
 
     /**
      * Await until a Atomic variable has a value matching the specified
-     * {@link org.hamcrest.Matcher}. E.g.
+     * {@link org.awaitility.core.Matcher}. E.g.
      * <p>&nbsp;</p>
      * <pre>
      * await().untilAtomic(myAtomic, is(greaterThan(2)));
      * </pre>
      *
      * @param atomic  the atomic variable
-     * @param matcher the matcher The hamcrest matcher that checks whether the
-     *                condition is fulfilled.
+     * @param matcher the matcher
      * @param <V>     a V object.
      * @return a V object.
      * @throws org.awaitility.core.ConditionTimeoutException If condition was not fulfilled within the given time period.
      */
     public <V> V untilAtomic(final AtomicReference<V> atomic, final Matcher<? super V> matcher) {
-        return until(new CallableHamcrestCondition<>(atomic::get, matcher, generateConditionSettings()));
+        return until(new CallableMatcherCondition<>(atomic::get, matcher, generateConditionSettings()));
     }
 
     /**

--- a/awaitility/src/main/java/org/awaitility/core/EvaluatedCondition.java
+++ b/awaitility/src/main/java/org/awaitility/core/EvaluatedCondition.java
@@ -16,8 +16,6 @@
 
 package org.awaitility.core;
 
-import org.hamcrest.Matcher;
-
 import java.time.Duration;
 
 /**
@@ -27,7 +25,7 @@ import java.time.Duration;
  */
 public class EvaluatedCondition<T> {
     private final String description;
-    private final Matcher<? super T> matcher;
+    private final Object matcher;
     private final T currentConditionValue;
     private final long elapsedTimeInMS;
     private final Duration pollInterval;
@@ -38,13 +36,13 @@ public class EvaluatedCondition<T> {
     /**
      * @param description           A descriptive match message or mismatch message of the matcher. If <code>isConditionSatisfied</code> is <code>true</code> then it
      *                              describes a match message, if <code>false</code> then it describes a mismatch message.
-     * @param matcher               The Hamcrest matcher used in the condition
+     * @param matcher               The matcher used in the condition (may be {@code null} for non-matcher conditions)
      * @param currentConditionValue The current value of the condition.
      * @param elapsedTimeInMS       elapsed time in milliseconds.
      * @param remainingTimeInMS     remaining time to wait in milliseconds; <code>Long.MAX_VALUE</code>, if no timeout defined, i.e., running forever.
-     * @param isConditionSatisfied  <code>true</code> if the condition is satisfied (i.e. hamcrest matcher matches the value), <code>false</code> otherwise (i.e. an intermediate value).
+     * @param isConditionSatisfied  <code>true</code> if the condition is satisfied (i.e. matcher matches the value), <code>false</code> otherwise (i.e. an intermediate value).
      */
-    EvaluatedCondition(String description, Matcher<? super T> matcher, T currentConditionValue, long elapsedTimeInMS, long remainingTimeInMS,
+    EvaluatedCondition(String description, Object matcher, T currentConditionValue, long elapsedTimeInMS, long remainingTimeInMS,
                        boolean isConditionSatisfied, String alias, Duration pollInterval) {
         this.description = description;
         this.matcher = matcher;
@@ -57,25 +55,26 @@ public class EvaluatedCondition<T> {
     }
 
     /**
-     * @return Descriptive message of the Hamcrest matcher.
+     * @return Descriptive message of the matcher.
      */
     public String getDescription() {
         return description;
     }
 
     /**
-     * @return <code>true</code> if the condition has a matcher (i.e. it's a Hamcrest Based condition) which means that {@link #getMatcher()} will return a non-null value.
+     * @return <code>true</code> if the condition has a matcher which means that {@link #getMatcher()} will return a non-null value.
      */
-    public boolean isHamcrestCondition() {
+    public boolean isMatcherCondition() {
         return matcher != null;
     }
 
     /**
-     * @return The Hamcrest matcher used in the condition if this condition is a Hamcrest condition
-     * @see #isHamcrestCondition()
+     * @return The matcher used in the condition if this condition is a matcher-based condition
+     * @see #isMatcherCondition()
      */
+    @SuppressWarnings("unchecked")
     public Matcher<? super T> getMatcher() {
-        return matcher;
+        return (Matcher<? super T>) matcher;
     }
 
     /**
@@ -107,7 +106,7 @@ public class EvaluatedCondition<T> {
     }
 
     /**
-     * @return <code>true</code> if the condition is satisfied (i.e. hamcrest matcher matches the value), <code>false</code> otherwise (i.e. an intermediate value).
+     * @return <code>true</code> if the condition is satisfied (i.e. matcher matches the value), <code>false</code> otherwise (i.e. an intermediate value).
      */
     public boolean isSatisfied() {
         return conditionIsFulfilled;

--- a/awaitility/src/main/java/org/awaitility/core/Matcher.java
+++ b/awaitility/src/main/java/org/awaitility/core/Matcher.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.awaitility.core;
+
+/**
+ * An interface for matching values in Awaitility conditions.
+ * <p>
+ * This is intentionally <b>not</b> a {@code @FunctionalInterface} to avoid
+ * ambiguity with {@link java.util.function.Predicate} overloads. Implementations
+ * must provide a {@link #describe()} method for meaningful error messages.
+ * </p>
+ *
+ * @param <T> the type of value to match
+ */
+public interface Matcher<T> {
+
+    /**
+     * Evaluates the matcher for the given value.
+     *
+     * @param value the value to match against
+     * @return {@code true} if the value matches, {@code false} otherwise
+     */
+    boolean matches(T value);
+
+    /**
+     * Returns a human-readable description of the expected value.
+     *
+     * @return a description of what the matcher expects
+     */
+    String describe();
+
+    /**
+     * Returns a human-readable description of why the given value did not match.
+     *
+     * @param value the value that did not match
+     * @return a description of the mismatch
+     */
+    default String describeMismatch(T value) {
+        return "was <" + value + ">";
+    }
+}

--- a/awaitility/src/main/java/org/awaitility/core/MatcherExceptionIgnorer.java
+++ b/awaitility/src/main/java/org/awaitility/core/MatcherExceptionIgnorer.java
@@ -16,13 +16,11 @@
 
 package org.awaitility.core;
 
-import org.hamcrest.Matcher;
-
-public class HamcrestExceptionIgnorer implements ExceptionIgnorer {
+public class MatcherExceptionIgnorer implements ExceptionIgnorer {
 
     private final Matcher<? super Throwable> matcher;
 
-    public HamcrestExceptionIgnorer(Matcher<? super Throwable> matcher) {
+    public MatcherExceptionIgnorer(Matcher<? super Throwable> matcher) {
         if (matcher == null) {
             throw new IllegalArgumentException("matcher cannot be null");
         }

--- a/awaitility/src/main/java/org/awaitility/core/MatcherToStringFilter.java
+++ b/awaitility/src/main/java/org/awaitility/core/MatcherToStringFilter.java
@@ -15,15 +15,13 @@
  */
 package org.awaitility.core;
 
-import org.hamcrest.Matcher;
-
 import java.util.LinkedList;
 import java.util.List;
 
 /**
- * The Class HamcrestToStringFilter.
+ * The Class MatcherToStringFilter.
  */
-class HamcrestToStringFilter {
+class MatcherToStringFilter {
 	private static final List<String> wordsToRemove = new LinkedList<String>();
 	static {
 		wordsToRemove.add("not not ");
@@ -31,18 +29,18 @@ class HamcrestToStringFilter {
 	}
 
 	/**
-	 * Filter words from the <code>matcher.toString()</code> so it looks nicer
+	 * Filter words from the matcher description so it looks nicer
 	 * when printed out. E.g. "not not" is removed and "is" are removed.
-	 * 
-	 * @param matcher
-	 *            the matcher
-	 * @return A filtered version of the {@link Matcher#toString()}.
+	 *
+	 * @param matcherDescription
+	 *            the matcher description string
+	 * @return A filtered version of the description.
 	 */
-	static String filter(Matcher<?> matcher) {
-		String matcherToString = matcher.toString();
+	static String filter(String matcherDescription) {
+		String result = matcherDescription;
 		for (String wordToRemove : wordsToRemove) {
-			matcherToString = matcherToString.replaceAll(wordToRemove, "");
+			result = result.replaceAll(wordToRemove, "");
 		}
-		return matcherToString;
+		return result;
 	}
 }

--- a/awaitility/src/main/java/org/awaitility/core/Matchers.java
+++ b/awaitility/src/main/java/org/awaitility/core/Matchers.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.awaitility.core;
+
+import java.util.Objects;
+
+/**
+ * Built-in {@link Matcher} factory methods for common matching operations.
+ * <p>
+ * These matchers can be used with {@link org.awaitility.core.ConditionFactory#until(java.util.concurrent.Callable, Matcher)}.
+ * </p>
+ */
+public final class Matchers {
+
+    private Matchers() {
+    }
+
+    public static <T> Matcher<T> equalTo(T expected) {
+        return new Matcher<T>() {
+            @Override
+            public boolean matches(T value) {
+                return Objects.equals(value, expected);
+            }
+
+            @Override
+            public String describe() {
+                return formatValue(expected);
+            }
+
+            @Override
+            public String describeMismatch(T value) {
+                return "was " + formatValue(value);
+            }
+        };
+    }
+
+    private static String formatValue(Object value) {
+        if (value instanceof String) {
+            return "\"" + value + "\"";
+        }
+        if (value instanceof Long) {
+            return "<" + value + "L>";
+        }
+        if (value instanceof Short) {
+            return "<" + value + "s>";
+        }
+        if (value instanceof Float) {
+            return "<" + value + "F>";
+        }
+        return "<" + value + ">";
+    }
+
+    public static <T extends Comparable<T>> Matcher<T> greaterThan(T expected) {
+        return new Matcher<T>() {
+            @Override
+            public boolean matches(T value) {
+                return value != null && value.compareTo(expected) > 0;
+            }
+
+            @Override
+            public String describe() {
+                return "a value greater than " + formatValue(expected);
+            }
+
+            @Override
+            public String describeMismatch(T value) {
+                if (value == null) {
+                    return "was null";
+                }
+                int cmp = value.compareTo(expected);
+                if (cmp == 0) {
+                    return formatValue(value) + " was equal to " + formatValue(expected);
+                }
+                return formatValue(value) + " was less than " + formatValue(expected);
+            }
+        };
+    }
+
+    public static <T> Matcher<T> is(Matcher<T> delegate) {
+        return delegate;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Matcher<T> is(T value) {
+        return (Matcher<T>) equalTo(value);
+    }
+
+    public static <T> Matcher<Iterable<? super T>> hasItem(T item) {
+        return new Matcher<Iterable<? super T>>() {
+            @Override
+            public boolean matches(Iterable<? super T> value) {
+                if (value == null) return false;
+                for (Object element : value) {
+                    if (Objects.equals(element, item)) return true;
+                }
+                return false;
+            }
+
+            @Override
+            public String describe() {
+                return "a collection containing <" + item + ">";
+            }
+        };
+    }
+
+    public static Matcher<Throwable> instanceOf(Class<?> type) {
+        return new Matcher<Throwable>() {
+            @Override
+            public boolean matches(Throwable value) {
+                return type.isInstance(value);
+            }
+
+            @Override
+            public String describe() {
+                return "an instance of " + type.getName();
+            }
+        };
+    }
+}

--- a/awaitility/src/main/java/org/awaitility/core/PredicateCondition.java
+++ b/awaitility/src/main/java/org/awaitility/core/PredicateCondition.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.awaitility.core;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+
+import static org.awaitility.core.LambdaErrorMessageGenerator.generateLambdaErrorMessagePrefix;
+import static org.awaitility.core.LambdaErrorMessageGenerator.isLambdaClass;
+import static org.awaitility.spi.Timeout.timeout_message;
+
+/**
+ * A {@link Condition} implementation that evaluates a {@link Callable} against a {@link Predicate}
+ * without requiring a {@link Matcher} on the classpath.
+ *
+ * @param <T> the type returned by the supplier
+ */
+class PredicateCondition<T> implements Condition<T> {
+
+    private final ConditionAwaiter conditionAwaiter;
+    private final ConditionEvaluationHandler<T> conditionEvaluationHandler;
+    private volatile T lastResult;
+
+    PredicateCondition(final Callable<T> supplier, final Predicate<? super T> predicate, final ConditionSettings settings) {
+        if (supplier == null) {
+            throw new IllegalArgumentException("You must specify a supplier (was null).");
+        }
+        if (predicate == null) {
+            throw new IllegalArgumentException("You must specify a predicate (was null).");
+        }
+
+        conditionEvaluationHandler = new ConditionEvaluationHandler<>(null, settings);
+        final ConditionEvaluator callable = new ConditionEvaluator() {
+            @Override
+            public ConditionEvaluationResult eval(Duration pollInterval) throws Exception {
+                lastResult = supplier.call();
+                boolean matches = predicate.test(lastResult);
+                if (matches) {
+                    conditionEvaluationHandler.handleConditionResultMatch(
+                            getMatchMessage(supplier), lastResult, pollInterval);
+                } else {
+                    conditionEvaluationHandler.handleConditionResultMismatch(
+                            getMismatchMessage(supplier), lastResult, pollInterval);
+                }
+                return new ConditionEvaluationResult(matches);
+            }
+        };
+
+        conditionAwaiter = new ConditionAwaiter(callable, settings) {
+            @SuppressWarnings("rawtypes")
+            @Override
+            protected String getTimeoutMessage() {
+                if (timeout_message != null) {
+                    return timeout_message;
+                }
+                return getMismatchMessage(supplier);
+            }
+        };
+    }
+
+    @Override
+    public T await() {
+        conditionAwaiter.await(conditionEvaluationHandler);
+        return lastResult;
+    }
+
+    private String getMatchMessage(Callable<T> supplier) {
+        return String.format("%s returned a value matching the predicate: <%s>",
+                getCallableDescription(supplier), String.valueOf(lastResult));
+    }
+
+    private String getMismatchMessage(Callable<T> supplier) {
+        return String.format("%s returned a value not matching the predicate: <%s>",
+                getCallableDescription(supplier), String.valueOf(lastResult));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private String getCallableDescription(Callable<T> supplier) {
+        final Class<? extends Callable> supplierClass = supplier.getClass();
+        Method enclosingMethod = supplierClass.getEnclosingMethod();
+        if (supplierClass.isAnonymousClass() && enclosingMethod != null) {
+            return enclosingMethod.getDeclaringClass().getName() + "." + enclosingMethod.getName() + " Callable";
+        } else if (isLambdaClass(supplierClass)) {
+            return generateLambdaErrorMessagePrefix(supplierClass, true);
+        } else {
+            return supplierClass.getName();
+        }
+    }
+}

--- a/awaitility/src/main/java/org/awaitility/core/StartEvaluationEvent.java
+++ b/awaitility/src/main/java/org/awaitility/core/StartEvaluationEvent.java
@@ -16,22 +16,20 @@
 
 package org.awaitility.core;
 
-import org.hamcrest.Matcher;
-
 public class StartEvaluationEvent<T> {
     private final String description;
-    private final Matcher<? super T> matcher;
+    private final Object matcher;
     private final long elapsedTimeInMS;
     private final long remainingTimeInMS;
     private final String alias;
 
     /**
      * @param description           description message of the event
-     * @param matcher               The Hamcrest matcher used in the condition
+     * @param matcher               The matcher used in the condition (may be {@code null} for non-matcher conditions)
      * @param elapsedTimeInMS       elapsed time in milliseconds.
      * @param remainingTimeInMS     remaining time to wait in milliseconds; <code>Long.MAX_VALUE</code>, if no timeout defined, i.e., running forever.
      */
-    StartEvaluationEvent(String description, Matcher<? super T> matcher, long elapsedTimeInMS, long remainingTimeInMS,
+    StartEvaluationEvent(String description, Object matcher, long elapsedTimeInMS, long remainingTimeInMS,
                          String alias) {
         this.description = description;
         this.matcher = matcher;
@@ -44,8 +42,9 @@ public class StartEvaluationEvent<T> {
         return description;
     }
 
+    @SuppressWarnings("unchecked")
     public Matcher<? super T> getMatcher() {
-        return matcher;
+        return (Matcher<? super T>) matcher;
     }
 
     public long getElapsedTimeInMS() {

--- a/awaitility/src/main/java/org/awaitility/core/TemporalDuration.java
+++ b/awaitility/src/main/java/org/awaitility/core/TemporalDuration.java
@@ -25,7 +25,13 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
-import static java.time.temporal.ChronoField.*;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
 
 class TemporalDuration implements TemporalAccessor {
     private static final Temporal BASE = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);

--- a/awaitility/src/main/java/org/awaitility/core/Uninterruptibles.java
+++ b/awaitility/src/main/java/org/awaitility/core/Uninterruptibles.java
@@ -14,7 +14,12 @@
 package org.awaitility.core;
 
 import java.time.Duration;
-import java.util.concurrent.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 

--- a/awaitility/src/test/java/org/awaitility/AwaitilityAccumulatorTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityAccumulatorTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.LongAccumulator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
+import static org.awaitility.core.Matchers.equalTo;
 
 public class AwaitilityAccumulatorTest {
 
@@ -64,7 +64,7 @@ public class AwaitilityAccumulatorTest {
         }).start();
 
         // Then
-        await().untilAccumulator(accumulator, value -> assertThat(value).isEqualTo(30L));
+        await().untilAccumulator(accumulator, value -> { assertThat(value).isEqualTo(30L); });
     }
 
     @Test(timeout = 2000)
@@ -104,6 +104,6 @@ public class AwaitilityAccumulatorTest {
         }).start();
 
         // Then
-        await().untilAccumulator(accumulator, value -> assertThat(value).isEqualTo(35.2d));
+        await().untilAccumulator(accumulator, value -> { assertThat(value).isEqualTo(35.2d); });
     }
 }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityAdderTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityAdderTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
+import static org.awaitility.core.Matchers.equalTo;
 
 public class AwaitilityAdderTest {
 
@@ -64,7 +64,7 @@ public class AwaitilityAdderTest {
         }).start();
 
         // Then
-        await().untilAdder(accumulator, value -> assertThat(value).isEqualTo(5L));
+        await().untilAdder(accumulator, value -> { assertThat(value).isEqualTo(5L); });
     }
 
     @Test(timeout = 2000)
@@ -104,6 +104,6 @@ public class AwaitilityAdderTest {
         }).start();
 
         // Then
-        await().untilAdder(accumulator, value -> assertThat(value).isEqualTo(5.5d));
+        await().untilAdder(accumulator, value -> { assertThat(value).isEqualTo(5.5d); });
     }
 }

--- a/awaitility/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityIgnoreExceptionsTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.awaitility.core.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -126,13 +126,13 @@ public class AwaitilityIgnoreExceptionsTest {
     @Test(timeout = 2000)
     public void exceptionIgnoringWorksForPredicates() {
         new Asynch(fakeRepository).perform();
-        await().atMost(1000, MILLISECONDS).with().ignoreExceptionsMatching(RuntimeException.class::isInstance).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
+        await().atMost(1000, MILLISECONDS).with().ignoreExceptionsMatching((java.util.function.Predicate<Throwable>) RuntimeException.class::isInstance).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 
     @Test(timeout = 2000)
     public void exceptionIgnoringWorksForPredicatesStatically() {
         new Asynch(fakeRepository).perform();
-        Awaitility.ignoreExceptionsByDefaultMatching(RuntimeException.class::isInstance);
+        Awaitility.ignoreExceptionsByDefaultMatching((java.util.function.Predicate<Throwable>) RuntimeException.class::isInstance);
         await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime(IllegalArgumentException.class));
     }
 

--- a/awaitility/src/test/java/org/awaitility/AwaitilityReturnValuesTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityReturnValuesTest.java
@@ -27,8 +27,8 @@ import java.util.concurrent.Callable;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.fieldIn;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.awaitility.core.Matchers.equalTo;
+import static org.awaitility.core.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
 public class AwaitilityReturnValuesTest {

--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -16,9 +16,19 @@
 package org.awaitility;
 
 import org.assertj.core.api.Assertions;
-import org.awaitility.classes.*;
-import org.awaitility.core.*;
-import org.hamcrest.Matcher;
+import org.awaitility.classes.AssertExceptionThrownInAnotherThreadButNeverCaughtByAnyThreadTest;
+import org.awaitility.classes.Asynch;
+import org.awaitility.classes.ExceptionThrowingAsynch;
+import org.awaitility.classes.ExceptionThrowingFakeRepository;
+import org.awaitility.classes.FakeRepository;
+import org.awaitility.classes.FakeRepositoryEqualsOne;
+import org.awaitility.classes.FakeRepositoryImpl;
+import org.awaitility.classes.FakeRepositoryValue;
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.EvaluatedCondition;
+import org.awaitility.core.ForeverDuration;
+import org.awaitility.core.TimeoutEvent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -40,12 +50,30 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static java.util.concurrent.TimeUnit.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.awaitility.Awaitility.*;
-import static org.awaitility.Durations.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.catchUncaughtExceptions;
+import static org.awaitility.Awaitility.catchUncaughtExceptionsByDefault;
+import static org.awaitility.Awaitility.dontCatchUncaughtExceptions;
+import static org.awaitility.Awaitility.given;
+import static org.awaitility.Awaitility.with;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.ONE_SECOND;
+import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
+import static org.awaitility.core.Matchers.equalTo;
+import static org.awaitility.core.Matchers.greaterThan;
+import static org.awaitility.core.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AwaitilityTest {
 
@@ -398,7 +426,7 @@ public class AwaitilityTest {
         exception
                 .expectMessage(String
                         .format("%s.valueAsAnonymous Callable expected %s but was <0> within 120 milliseconds.",
-                                AwaitilityTest.class.getName(), equalTo(2).toString()));
+                                AwaitilityTest.class.getName(), Matchers.equalTo(2).toString()));
 
         with().pollInterval(10, MILLISECONDS).await().atMost(120, MILLISECONDS).until(valueAsAnonymous(), equalTo(2));
     }
@@ -407,10 +435,10 @@ public class AwaitilityTest {
     @Test(timeout = 2000)
     public void awaitDisplaysMethodDeclaringTheSupplierWhenSupplierIsAnonymousClassAndConditionTimeoutExceptionOccursWhenUsingNanos() {
         exception.expect(ConditionTimeoutException.class);
-        exception.expectMessage(Matchers.anyOf(Stream.of(equalTo(0).toString(), "null")
-                .map(s -> String.format("%s.valueAsAnonymous Callable expected %s but was %s within 120 nanoseconds.", AwaitilityTest.class.getName(), equalTo(2).toString(), s))
+        exception.expectMessage(Matchers.anyOf(Stream.of(Matchers.equalTo(0).toString(), "null")
+                .map(s -> String.format("%s.valueAsAnonymous Callable expected %s but was %s within 120 nanoseconds.", AwaitilityTest.class.getName(), Matchers.equalTo(2).toString(), s))
                 .map(Matchers::containsString)
-                .toArray(Matcher[]::new)));
+                .toArray(org.hamcrest.Matcher[]::new)));
 
         with().pollInterval(10, NANOSECONDS).await().atMost(120, NANOSECONDS).until(valueAsAnonymous(), equalTo(2));
     }
@@ -461,7 +489,7 @@ public class AwaitilityTest {
                 .until(() -> true)
         );
 
-        assertThat(duration.toMillis(), greaterThan(1000L));
+        assertThat(duration.toMillis(), Matchers.greaterThan(1000L));
     }
 
     @Test(timeout = 2500L)
@@ -476,7 +504,7 @@ public class AwaitilityTest {
                 )
         );
 
-        assertThat(duration.toMillis(), greaterThan(1500L));
+        assertThat(duration.toMillis(), Matchers.greaterThan(1500L));
     }
 
     @Test(timeout = 2000L, expected = ConditionTimeoutException.class)
@@ -508,7 +536,7 @@ public class AwaitilityTest {
                 .until(() -> true)
         );
 
-        assertThat(duration.toMillis(), greaterThan(1000L));
+        assertThat(duration.toMillis(), Matchers.greaterThan(1000L));
     }
 
     @Test

--- a/awaitility/src/test/java/org/awaitility/BoxingTest.java
+++ b/awaitility/src/test/java/org/awaitility/BoxingTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.awaitility.core.Matchers.greaterThan;
 
 @SuppressWarnings("UnnecessaryBoxing")
 public class BoxingTest {

--- a/awaitility/src/test/java/org/awaitility/ConditionEvaluationListenerTest.java
+++ b/awaitility/src/test/java/org/awaitility/ConditionEvaluationListenerTest.java
@@ -18,25 +18,34 @@ package org.awaitility;
 
 import org.awaitility.core.ConditionEvaluationListener;
 import org.awaitility.core.EvaluatedCondition;
+import org.awaitility.core.Matcher;
 import org.awaitility.core.StartEvaluationEvent;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.setDefaultConditionEvaluationListener;
 import static org.awaitility.Awaitility.with;
 import static org.awaitility.Durations.ONE_SECOND;
 import static org.awaitility.Durations.TEN_SECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.awaitility.core.Matchers.equalTo;
+import static org.awaitility.core.Matchers.is;
 
 public class ConditionEvaluationListenerTest {
     @Rule
@@ -73,10 +82,10 @@ public class ConditionEvaluationListenerTest {
         Awaitility.setDefaultConditionEvaluationListener(defaultConditionEvaluationListener);
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(15)));
+        assertThat(globalCountDown.get()).isEqualTo(15);
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(10)));
+        assertThat(globalCountDown.get()).isEqualTo(10);
     }
 
     @Test(timeout = 2000)
@@ -95,15 +104,15 @@ public class ConditionEvaluationListenerTest {
         setDefaultConditionEvaluationListener(defaultConditionEvaluationListener);
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(15)));
+        assertThat(globalCountDown.get()).isEqualTo(15);
 
         with()
                 .conditionEvaluationListener(null)
                 .until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(15)));
+        assertThat(globalCountDown.get()).isEqualTo(15);
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(10)));
+        assertThat(globalCountDown.get()).isEqualTo(10);
     }
 
     @Test(timeout = 2000)
@@ -121,12 +130,12 @@ public class ConditionEvaluationListenerTest {
         setDefaultConditionEvaluationListener(defaultConditionEvaluationListener);
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(15)));
+        assertThat(globalCountDown.get()).isEqualTo(15);
 
         Awaitility.reset();
 
         with().until(new CountDown(5), is(equalTo(0)));
-        assertThat(globalCountDown.get(), is(equalTo(15)));
+        assertThat(globalCountDown.get()).isEqualTo(15);
     }
 
     @Test(timeout = 10000)
@@ -154,7 +163,7 @@ public class ConditionEvaluationListenerTest {
                 })
                 .until(new CountDown(5), is(equalTo(0)));
 
-        assertThat(buffer.size(), is(equalTo(5 + 1)));
+        assertThat(buffer.size()).isEqualTo(5 + 1);
     }
 
 
@@ -170,7 +179,7 @@ public class ConditionEvaluationListenerTest {
                 .until(new CountDownProvider(new CountDownBean(10, 20)), samePropertyValuesAs(new CountDownBean(10, 10)));
 
         String expectedMismatchMessage = String.format("%s expected same property values as CountDownBean [countDown: <10>, secondCountDown: <10>] but secondCountDown was <11>", CountDownProvider.class.getName());
-        assertThat(lastMismatchMessage.value, is(equalTo(expectedMismatchMessage)));
+        assertThat(lastMismatchMessage.value).isEqualTo(expectedMismatchMessage);
 
     }
 
@@ -186,7 +195,7 @@ public class ConditionEvaluationListenerTest {
                 .until(new CountDown(10), is(equalTo(5)));
 
         String expectedMismatchMessage = String.format("%s expected <5> but was <6>", CountDown.class.getName());
-        assertThat(lastMismatchMessage.value, is(equalTo(expectedMismatchMessage)));
+        assertThat(lastMismatchMessage.value).isEqualTo(expectedMismatchMessage);
 
     }
 
@@ -198,7 +207,7 @@ public class ConditionEvaluationListenerTest {
                 .until(new CountDown(10), is(equalTo(5)));
 
         String expectedMatchMessage = String.format("%s reached its end value of <5>", CountDown.class.getName());
-        assertThat(lastMatchMessage.value, is(equalTo(expectedMatchMessage)));
+        assertThat(lastMatchMessage.value).isEqualTo(expectedMatchMessage);
     }
 
     @Test(timeout = 2000)
@@ -224,8 +233,8 @@ public class ConditionEvaluationListenerTest {
                 .until(new CountDown(10), is(equalTo(5)));
 
         String expectedMatchMessage = String.format("%s reached its end value of <5>", CountDown.class.getName());
-        assertThat(lastMatchMessage.value, is(equalTo(expectedMatchMessage)));
-        assertThat(beforeEvaluation.value, is(equalTo(BigInteger.ONE)));
+        assertThat(lastMatchMessage.value).isEqualTo(expectedMatchMessage);
+        assertThat(beforeEvaluation.value).isEqualTo(BigInteger.ONE);
     }
 
     @Test(timeout = 2000)
@@ -240,8 +249,111 @@ public class ConditionEvaluationListenerTest {
                 .forever()
                 .until(new CountDown(10), is(equalTo(5)));
 
-        assertThat(remainingTimes, everyItem(is(Long.MAX_VALUE)));
-        assertThat(elapsedTimes, everyItem(is(not(Long.MAX_VALUE))));
+        assertThat(remainingTimes).allSatisfy(v -> assertThat(v).isEqualTo(Long.MAX_VALUE));
+        assertThat(elapsedTimes).allSatisfy(v -> assertThat(v).isNotEqualTo(Long.MAX_VALUE));
+    }
+
+    @Test(timeout = 2000)
+    public void evaluatedConditionGetMatcherReturnsTheMatcherUsedInCondition() {
+        final AtomicReference<Matcher<? super Integer>> capturedMatcher = new AtomicReference<>();
+        Matcher<? super Integer> expectedMatcher = is(equalTo(5));
+
+        with()
+                .conditionEvaluationListener(condition -> {
+                    if (condition.isMatcherCondition()) {
+                        capturedMatcher.set(condition.getMatcher());
+                    }
+                })
+                .until(new CountDown(10), expectedMatcher);
+
+        assertThat(capturedMatcher.get()).isNotNull();
+        assertThat(capturedMatcher.get()).isSameAs(expectedMatcher);
+    }
+
+    @Test(timeout = 2000)
+    public void startEvaluationEventGetMatcherReturnsTheMatcherUsedInCondition() {
+        final AtomicReference<Matcher<? super Integer>> capturedMatcher = new AtomicReference<>();
+        Matcher<? super Integer> expectedMatcher = is(equalTo(5));
+
+        ConditionEvaluationListener<Integer> listener = new ConditionEvaluationListener<Integer>() {
+            @Override
+            public void conditionEvaluated(EvaluatedCondition<Integer> condition) {
+            }
+
+            @Override
+            public void beforeEvaluation(StartEvaluationEvent<Integer> startEvaluationEvent) {
+                capturedMatcher.set(startEvaluationEvent.getMatcher());
+            }
+        };
+
+        with()
+                .conditionEvaluationListener(listener)
+                .until(new CountDown(10), expectedMatcher);
+
+        assertThat(capturedMatcher.get()).isNotNull();
+        assertThat(capturedMatcher.get()).isSameAs(expectedMatcher);
+    }
+
+    private static <T> Matcher<T> samePropertyValuesAs(T expected) {
+        return new Matcher<T>() {
+            @Override
+            public boolean matches(T value) {
+                if (value == null || expected == null) return value == expected;
+                try {
+                    BeanInfo beanInfo = Introspector.getBeanInfo(expected.getClass(), Object.class);
+                    for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+                        Method getter = pd.getReadMethod();
+                        if (getter == null) continue;
+                        Object expectedVal = getter.invoke(expected);
+                        Object actualVal = getter.invoke(value);
+                        if (!Objects.equals(expectedVal, actualVal)) return false;
+                    }
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }
+
+            @Override
+            public String describe() {
+                return "same property values as " + beanDescription(expected);
+            }
+
+            @Override
+            public String describeMismatch(T value) {
+                if (value == null) return "was null";
+                try {
+                    BeanInfo beanInfo = Introspector.getBeanInfo(expected.getClass(), Object.class);
+                    for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+                        Method getter = pd.getReadMethod();
+                        if (getter == null) continue;
+                        Object expectedVal = getter.invoke(expected);
+                        Object actualVal = getter.invoke(value);
+                        if (!Objects.equals(expectedVal, actualVal)) {
+                            return pd.getName() + " was <" + actualVal + ">";
+                        }
+                    }
+                } catch (Exception e) {
+                    return "was <" + value + ">";
+                }
+                return "was <" + value + ">";
+            }
+
+            private String beanDescription(Object bean) {
+                try {
+                    BeanInfo beanInfo = Introspector.getBeanInfo(bean.getClass(), Object.class);
+                    StringJoiner joiner = new StringJoiner(", ");
+                    for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+                        Method getter = pd.getReadMethod();
+                        if (getter == null) continue;
+                        joiner.add(pd.getName() + ": <" + getter.invoke(bean) + ">");
+                    }
+                    return bean.getClass().getSimpleName() + " [" + joiner + "]";
+                } catch (Exception e) {
+                    return bean.toString();
+                }
+            }
+        };
     }
 
     private static class CountDown implements Callable<Integer> {

--- a/awaitility/src/test/java/org/awaitility/DeadlockDetectionTest.java
+++ b/awaitility/src/test/java/org/awaitility/DeadlockDetectionTest.java
@@ -26,7 +26,9 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_SECOND;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class DeadlockDetectionTest {
 

--- a/awaitility/src/test/java/org/awaitility/FailFastTest.java
+++ b/awaitility/src/test/java/org/awaitility/FailFastTest.java
@@ -18,8 +18,6 @@ package org.awaitility;
 
 import org.awaitility.core.TerminalFailureException;
 import org.awaitility.core.ThrowingRunnable;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,8 +28,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.core.Matchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Fast failure on terminal status #178
@@ -53,7 +53,7 @@ public class FailFastTest {
     @Test
     public void fail_fast_throws_terminal_failure_exception_with_the_supplied_failure_reason() {
         exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("System crash"));
+        exception.expectMessage("System crash");
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -79,7 +79,7 @@ public class FailFastTest {
     @Test
     public void fail_fast_throws_terminal_failure_exception_with_the_default_failure_reason_when_no_failure_reason_is_specified() {
         exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("Fail fast condition triggered"));
+        exception.expectMessage("Fail fast condition triggered");
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -105,7 +105,7 @@ public class FailFastTest {
     @Test
     public void statically_configured_fail_fast_condition_without_failure_reason() {
         exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("Fail fast condition triggered"));
+        exception.expectMessage("Fail fast condition triggered");
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -131,7 +131,7 @@ public class FailFastTest {
     @Test
     public void statically_configured_fail_fast_condition_with_failure_reason() {
         exception.expect(TerminalFailureException.class);
-        exception.expectMessage(equalTo("System crash"));
+        exception.expectMessage("System crash");
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -210,7 +210,7 @@ public class FailFastTest {
     public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_assertions_with_explicit_reason() {
         exception.expect(TerminalFailureException.class);
         exception.expectMessage("fail fast reason");
-        exception.expectCause(instanceOf(AssertionError.class));
+        exception.expectCause(org.hamcrest.CoreMatchers.instanceOf(AssertionError.class));
 
         AtomicInteger ai = new AtomicInteger(0);
 
@@ -237,7 +237,7 @@ public class FailFastTest {
     public void fail_fast_throws_terminal_failure_exception_without_reason_when_using_default_assertions_with_explicit_reason() {
         exception.expect(TerminalFailureException.class);
         exception.expectMessage("fail fast reason");
-        exception.expectCause(instanceOf(AssertionError.class));
+        exception.expectCause(org.hamcrest.CoreMatchers.instanceOf(AssertionError.class));
 
         AtomicInteger ai = new AtomicInteger(0);
 

--- a/awaitility/src/test/java/org/awaitility/UsingAtomicTest.java
+++ b/awaitility/src/test/java/org/awaitility/UsingAtomicTest.java
@@ -30,10 +30,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
+import static org.awaitility.core.Matchers.equalTo;
 
 public class UsingAtomicTest {
     @Rule
@@ -55,7 +54,7 @@ public class UsingAtomicTest {
     public void usingAtomicIntegerWithConsumerMatcher() {
         AtomicInteger atomic = new AtomicInteger(0);
         new Asynch(new FakeRepositoryWithAtomicInteger(atomic)).perform();
-        await().untilAtomic(atomic, value -> assertThat(value).isEqualTo(1));
+        await().untilAtomic(atomic, value -> { assertThat(value).isEqualTo(1); });
     }
 
     @Test(timeout = 2000)
@@ -77,7 +76,7 @@ public class UsingAtomicTest {
     public void usingAtomicBooleanWithConsumerMatcher() {
         AtomicBoolean atomic = new AtomicBoolean(false);
         new Asynch(new FakeRepositoryWithAtomicBoolean(atomic)).perform();
-        await().untilAtomic(atomic, value -> assertThat(value).isTrue());
+        await().untilAtomic(atomic, value -> { assertThat(value).isTrue(); });
     }
 
     @Test(timeout = 2000)
@@ -99,7 +98,7 @@ public class UsingAtomicTest {
     public void usingAtomicLongWithConsumerMatcher() {
         AtomicLong atomic = new AtomicLong(0);
         new Asynch(new FakeRepositoryWithAtomicLong(atomic)).perform();
-        await().untilAtomic(atomic, value -> assertThat(value).isEqualTo(1L));
+        await().untilAtomic(atomic, value -> { assertThat(value).isEqualTo(1L); });
     }
 
     @Test(timeout = 2000)
@@ -124,7 +123,7 @@ public class UsingAtomicTest {
     public void usingAtomicReferenceWithConsumerMatcher() {
         AtomicReference<String> atomic = new AtomicReference<>("0");
         new Asynch(new FakeRepositoryWithAtomicReference(atomic)).perform();
-        await().untilAtomic(atomic, value -> assertThat(value).isEqualTo("1"));
+        await().untilAtomic(atomic, value -> { assertThat(value).isEqualTo("1"); });
     }
 
     @Test(timeout = 2000)

--- a/awaitility/src/test/java/org/awaitility/UsingFieldSupplierTest.java
+++ b/awaitility/src/test/java/org/awaitility/UsingFieldSupplierTest.java
@@ -15,7 +15,13 @@
  */
 package org.awaitility;
 
-import org.awaitility.classes.*;
+import org.awaitility.classes.Asynch;
+import org.awaitility.classes.ExampleAnnotation;
+import org.awaitility.classes.ExampleAnnotation2;
+import org.awaitility.classes.FakeRepository;
+import org.awaitility.classes.FakeRepositoryImpl;
+import org.awaitility.classes.FakeRepositoryWithAnnotation;
+import org.awaitility.classes.FakeRepositoryWithStaticFieldAndAnnotation;
 import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.reflect.exception.FieldNotFoundException;
 import org.junit.Before;
@@ -26,7 +32,7 @@ import org.junit.rules.ExpectedException;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.fieldIn;
-import static org.hamcrest.Matchers.equalTo;
+import static org.awaitility.core.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
 public class UsingFieldSupplierTest {

--- a/awaitility/src/test/java/org/awaitility/WaitForAtomicBooleanTest.java
+++ b/awaitility/src/test/java/org/awaitility/WaitForAtomicBooleanTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.awaitility.core.Matchers.equalTo;
 
 public class WaitForAtomicBooleanTest {
     private AtomicBoolean wasAdded;

--- a/awaitility/src/test/java/org/awaitility/classes/ThrowExceptionUnlessFakeRepositoryEqualsOne.java
+++ b/awaitility/src/test/java/org/awaitility/classes/ThrowExceptionUnlessFakeRepositoryEqualsOne.java
@@ -35,15 +35,30 @@ public class ThrowExceptionUnlessFakeRepositoryEqualsOne implements Callable<Boo
         if (repository.getValue() != 1) {
             Throwable throwable;
             try {
-                Constructor<? extends Throwable> constructor = this.throwable.getDeclaredConstructor(String.class);
-                constructor.setAccessible(true);
-                throwable = constructor.newInstance("Repository value is not 1");
+                throwable = createThrowable(this.throwable, "Repository value is not 1");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
             CheckedExceptionRethrower.safeRethrow(throwable);
         }
         return true;
+    }
+
+    private static Throwable createThrowable(Class<? extends Throwable> type, String message) throws Exception {
+        // Try String constructor first (most Exception subclasses)
+        try {
+            Constructor<? extends Throwable> constructor = type.getConstructor(String.class);
+            return constructor.newInstance(message);
+        } catch (NoSuchMethodException ignored) {
+        }
+        // Fall back to Object constructor (e.g. AssertionError)
+        try {
+            Constructor<? extends Throwable> constructor = type.getConstructor(Object.class);
+            return constructor.newInstance(message);
+        } catch (NoSuchMethodException ignored) {
+        }
+        // Fall back to no-arg constructor
+        return type.getConstructor().newInstance();
     }
 }
 

--- a/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/ConditionEvaluationLoggerTest.java
@@ -29,8 +29,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.core.ConditionEvaluationLogger.conditionEvaluationLogger;
+import static org.awaitility.core.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 
 public class ConditionEvaluationLoggerTest {
 
@@ -178,7 +182,7 @@ public class ConditionEvaluationLoggerTest {
 
         assertThat(logs, everyItem(anyOf(equalTo("Starting evaluation"), containsString("expected <4> but was"), containsString("reached its end value of <4>"))));
     }
-    
+
     @Test(timeout = 2000)
     public void it_is_possible_to_override_the_way_condition_evaluation_logger_logs_the_results_when_using_static_method_to_create_the_condition_evaluation_logger() {
         CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();

--- a/awaitility/src/test/java/org/awaitility/core/MatcherToStringFilterTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/MatcherToStringFilterTest.java
@@ -17,28 +17,30 @@ package org.awaitility.core;
 
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
-public class HamcrestToStringFilterTest {
+public class MatcherToStringFilterTest {
 
 	@Test
 	public void removesIsFromToString() throws Exception {
-		assertEquals("<4>", HamcrestToStringFilter.filter(is(equalTo(4))));
+		assertEquals("<4>", MatcherToStringFilter.filter(is(equalTo(4)).toString()));
 	}
 
 	@Test
 	public void removesNotNotFromToString() throws Exception {
-		assertEquals("<4>", HamcrestToStringFilter.filter(not(not((equalTo(4))))));
+		assertEquals("<4>", MatcherToStringFilter.filter(not(not((equalTo(4)))).toString()));
 	}
 
 	@Test
 	public void removesAllNotNotsFromToString() throws Exception {
-		assertEquals("<4>", HamcrestToStringFilter.filter(not(not(not(not((equalTo(4))))))));
+		assertEquals("<4>", MatcherToStringFilter.filter(not(not(not(not((equalTo(4)))))).toString()));
 	}
 
 	@Test
 	public void removesNotNotButKeepsRemainingNotFromToString() throws Exception {
-		assertEquals("not <4>", HamcrestToStringFilter.filter(not(not(not((equalTo(4)))))));
+		assertEquals("not <4>", MatcherToStringFilter.filter(not(not(not((equalTo(4))))).toString()));
 	}
 }

--- a/awaitility/src/test/java/org/awaitility/core/MatchersTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/MatchersTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.awaitility.core;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MatchersTest {
+
+    // equalTo
+
+    @Test
+    public void equalToMatchesEqualValues() {
+        assertTrue(Matchers.equalTo(42).matches(42));
+    }
+
+    @Test
+    public void equalToDoesNotMatchDifferentValues() {
+        assertFalse(Matchers.equalTo(42).matches(99));
+    }
+
+    @Test
+    public void equalToMatchesNullWithNull() {
+        assertTrue(Matchers.equalTo(null).matches(null));
+    }
+
+    @Test
+    public void equalToDoesNotMatchNullWithNonNull() {
+        assertFalse(Matchers.equalTo(null).matches("hello"));
+    }
+
+    @Test
+    public void equalToDoesNotMatchNonNullWithNull() {
+        assertFalse(Matchers.equalTo("hello").matches(null));
+    }
+
+    @Test
+    public void equalToDescribeFormatsString() {
+        assertEquals("\"hello\"", Matchers.equalTo("hello").describe());
+    }
+
+    @Test
+    public void equalToDescribeFormatsInteger() {
+        assertEquals("<42>", Matchers.equalTo(42).describe());
+    }
+
+    @Test
+    public void equalToDescribeFormatsLong() {
+        assertEquals("<42L>", Matchers.equalTo(42L).describe());
+    }
+
+    @Test
+    public void equalToDescribeFormatsShort() {
+        assertEquals("<42s>", Matchers.equalTo((short) 42).describe());
+    }
+
+    @Test
+    public void equalToDescribeFormatsFloat() {
+        assertEquals("<1.5F>", Matchers.equalTo(1.5f).describe());
+    }
+
+    @Test
+    public void equalToDescribeMismatch() {
+        assertEquals("was <99>", Matchers.equalTo(42).describeMismatch(99));
+    }
+
+    @Test
+    public void equalToDescribeMismatchFormatsString() {
+        assertEquals("was \"actual\"", Matchers.equalTo("expected").describeMismatch("actual"));
+    }
+
+    // greaterThan
+
+    @Test
+    public void greaterThanMatchesGreaterValue() {
+        assertTrue(Matchers.greaterThan(5).matches(6));
+    }
+
+    @Test
+    public void greaterThanDoesNotMatchEqualValue() {
+        assertFalse(Matchers.greaterThan(5).matches(5));
+    }
+
+    @Test
+    public void greaterThanDoesNotMatchLesserValue() {
+        assertFalse(Matchers.greaterThan(5).matches(4));
+    }
+
+    @Test
+    public void greaterThanDoesNotMatchNull() {
+        assertFalse(Matchers.greaterThan(5).matches(null));
+    }
+
+    @Test
+    public void greaterThanDescribe() {
+        assertEquals("a value greater than <5>", Matchers.greaterThan(5).describe());
+    }
+
+    @Test
+    public void greaterThanDescribeMismatchForNull() {
+        assertEquals("was null", Matchers.greaterThan(5).describeMismatch(null));
+    }
+
+    @Test
+    public void greaterThanDescribeMismatchForEqualValue() {
+        assertEquals("<5> was equal to <5>", Matchers.greaterThan(5).describeMismatch(5));
+    }
+
+    @Test
+    public void greaterThanDescribeMismatchForLesserValue() {
+        assertEquals("<3> was less than <5>", Matchers.greaterThan(5).describeMismatch(3));
+    }
+
+    // is(Matcher)
+
+    @Test
+    public void isDelegateReturnsSameMatcher() {
+        Matcher<Integer> delegate = Matchers.equalTo(1);
+        assertTrue(Matchers.is(delegate) == delegate);
+    }
+
+    // is(T)
+
+    @Test
+    public void isValueMatchesEqualValue() {
+        assertTrue(Matchers.is(42).matches(42));
+    }
+
+    @Test
+    public void isValueDoesNotMatchDifferentValue() {
+        assertFalse(Matchers.is(42).matches(99));
+    }
+
+    // hasItem
+
+    @Test
+    public void hasItemMatchesWhenItemPresent() {
+        assertTrue(Matchers.hasItem("b").matches(Arrays.asList("a", "b", "c")));
+    }
+
+    @Test
+    public void hasItemDoesNotMatchWhenItemAbsent() {
+        assertFalse(Matchers.hasItem("z").matches(Arrays.asList("a", "b", "c")));
+    }
+
+    @Test
+    public void hasItemDoesNotMatchNull() {
+        assertFalse(Matchers.hasItem("a").matches(null));
+    }
+
+    @Test
+    public void hasItemDoesNotMatchEmptyCollection() {
+        assertFalse(Matchers.hasItem("a").matches(Collections.emptyList()));
+    }
+
+    @Test
+    public void hasItemDescribe() {
+        assertEquals("a collection containing <hello>", Matchers.hasItem("hello").describe());
+    }
+
+    // instanceOf
+
+    @Test
+    public void instanceOfMatchesExactType() {
+        assertTrue(Matchers.instanceOf(IllegalArgumentException.class).matches(new IllegalArgumentException()));
+    }
+
+    @Test
+    public void instanceOfMatchesSubtype() {
+        assertTrue(Matchers.instanceOf(RuntimeException.class).matches(new IllegalArgumentException()));
+    }
+
+    @Test
+    public void instanceOfDoesNotMatchDifferentType() {
+        assertFalse(Matchers.instanceOf(IllegalStateException.class).matches(new IllegalArgumentException()));
+    }
+
+    @Test
+    public void instanceOfDescribe() {
+        assertEquals("an instance of java.lang.IllegalArgumentException", Matchers.instanceOf(IllegalArgumentException.class).describe());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,18 +75,42 @@
     </prerequisites>
 
     <properties>
-        <hamcrest.version>2.1</hamcrest.version>
+        <!-- Dependency versions -->
+        <assertj.version>3.27.7</assertj.version>
+        <hamcrest.version>3.0</hamcrest.version>
+        <felix.version>7.0.5</felix.version>
+        <junit.version>4.13.2</junit.version>
+        <pax-exam.version>4.14.0</pax-exam.version>
+        <pax-swissbox.version>1.9.0</pax-swissbox.version>
+        <slf4j.version>2.0.17</slf4j.version>
+
+        <!-- Plugin versions -->
+        <animal-sniffer-maven-plugin.version>1.27</animal-sniffer-maven-plugin.version>
+        <depends-maven-plugin.version>1.5.0</depends-maven-plugin.version>
+        <gmavenplus-plugin.version>4.0.1</gmavenplus-plugin.version>
+        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+        <gmavenplus-plugin.version>4.0.1</gmavenplus-plugin.version>
+        <maven-bundle-plugin.version>6.0.2</maven-bundle-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
+        <maven-help-plugin.version>3.5.1</maven-help-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+        <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <scala-maven-plugin.version>4.9.2</scala-maven-plugin.version>
+        <surefire.version>3.5.5</surefire.version>
+        <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
+
+        <!-- Build settings -->
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven.version>3.5.0</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scm.branch>master</scm.branch>
-        <slf4j.version>2.0.16</slf4j.version>
-        <surefire.reportFormat>plain</surefire.reportFormat>
-        <surefire.useFile>false</surefire.useFile>
-        <surefire.version>3.5.2</surefire.version>
     </properties>
 
     <modules>
@@ -101,15 +125,15 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -121,7 +145,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${maven-release-plugin.version}</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
@@ -140,7 +164,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.18</version>
+                <version>${animal-sniffer-maven-plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -161,16 +185,16 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven-dependency-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-help-plugin</artifactId>
-                <version>2.2</version>
+                <version>${maven-help-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.18.0</version>
+                <version>${versions-maven-plugin.version}</version>
             </plugin>
 
         </plugins>
@@ -202,7 +226,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <version>${junit.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.hamcrest</groupId>
@@ -218,7 +242,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.21.0</version>
+                <version>${assertj.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -263,7 +287,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
Main changes
- removes hamcrest from compile scope and transitive dependencies, keep it in test scope.
  methods in ConditionFactory and Awaitility that previously accepted org.hamcrest.Matcher now accept org.awaitility.core.Matcher:

  - until(Callable<T>, Matcher<? super T>)
  - untilAtomic(AtomicInteger, Matcher<? super Integer>)
  - untilAtomic(AtomicLong, Matcher<? super Long>)
  - untilAtomic(AtomicBoolean, Matcher<? super Boolean>)
  - untilAdder / untilAccumulator variants
  - ignoreExceptionsMatching(Matcher<? super Throwable>)
  
 - upgrades dependencies of artifacts and plugins
   - `org.hamcrest:hamcrest` 2.1 → 3.0 (scope changed from **compile** to **test**)
   - `org.assertj:assertj-core` 3.21.0 → 3.27.7
   - `org.slf4j:slf4j-api` 2.0.16 → 2.0.17
   - `org.apache.groovy:groovy-all` 4.0.19 → 4.0.30
   - `org.jetbrains.kotlin:kotlin-stdlib` 2.1.10 → 2.3.0
   - `org.jetbrains.dokka:dokka-maven-plugin` 2.0.0 → 2.1.0
   - `org.scala-lang:scala-library` 2.13.13 → 2.13.18
   - `org.spockframework:spock-core` 2.4-M2-groovy-4.0 → 2.4-groovy-4.0
   - `org.apache.felix:org.apache.felix.framework` 5.6.4 → 7.0.5
   - `org.ops4j.pax.exam` 4.13.4 → 4.14.0
   - `org.ops4j.pax.swissbox:pax-swissbox-tinybundles` 1.8.3 → 1.9.0
   - `maven-compiler-plugin` 3.14.0 → 3.15.0
   - `maven-jar-plugin` 2.4 → 3.3.0
   - `maven-shade-plugin` 2.4.3 → 3.5.1
   - `maven-release-plugin` 3.1.1 → 3.3.1
   - `maven-javadoc-plugin` 3.11.2 → 3.12.0
   - `maven-source-plugin` 2.2.1 → 3.3.1
   - `maven-dependency-plugin` 3.8.1 → 3.10.0
   - `maven-help-plugin` 2.2 → 3.5.1
   - `maven-surefire-plugin` 3.5.2 → 3.5.5
   - `maven-bundle-plugin` (felix) — centralized to 6.0.2
   - `animal-sniffer-maven-plugin` 1.18 → 1.27
   - `versions-maven-plugin` 2.18.0 → 2.21.0
   - `scala-maven-plugin` 4.3.0 → 4.9.2
   - `build-helper-maven-plugin` 3.0.0 → 3.6.0
   - `gmavenplus-plugin` 1.7.1 → 4.0.1
   - `depends-maven-plugin` 1.3.1 → 1.5.0


To migrate from current version:

  1. Replace org.hamcrest.Matchers.* with org.awaitility.core.Matchers.* in until() calls
  2. Replace isHamcrestCondition() with isMatcherCondition() in ConditionEvaluationListener implementations
  3. If using custom Hamcrest matchers, implement org.awaitility.core.Matcher<T> instead
  4. Hamcrest can be removed from your project's dependencies if only used through awaitility