### PR TITLE
Bump assertj-core from 3.21.0 to 3.27.7 (CVE-2026-24400)

### DIFF
--- a/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/org/awaitility/AwaitilityTest.java
@@ -285,7 +285,7 @@ public class AwaitilityTest {
                     throw new Exception("Nested");
                 }
             });
-            fail();
+            org.junit.Assert.fail();
         } catch (ConditionTimeoutException e) {
             assertNotNull(e.getCause());
             assertEquals("Nested", e.getCause().getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.21.0</version>
+                <version>3.27.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Bumps `assertj-core` from 3.21.0 to 3.27.7 to resolve CVE-2026-24400 (XXE injection in `XmlStringPrettyFormatter`, affects versions 1.4.0 through 3.27.6).

Closes #301

References:
- https://nvd.nist.gov/vuln/detail/CVE-2026-24400
- https://github.com/awaitility/awaitility/issues/301