### PR TITLE
Parse leading digits in JavaVersionDetector for EA builds

### DIFF
--- a/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
+++ b/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
@@ -8,19 +8,20 @@ public final class JavaVersionDetector {
     }
 
     static int getJavaMajorVersion(String javaVersion) {
-        final String normalizedJavaVersion;
         if (javaVersion == null || javaVersion.isEmpty()) {
             // Fallback to java 8
-            normalizedJavaVersion = "8";
-        } else if (javaVersion.startsWith("1.")) {
-            normalizedJavaVersion = javaVersion.substring(2, 3);
-        } else if (javaVersion.indexOf('.') != -1) {
-            normalizedJavaVersion = javaVersion.substring(0, javaVersion.indexOf('.'));
-        } else if (javaVersion.indexOf('-') != -1) {
-            normalizedJavaVersion = javaVersion.substring(0, javaVersion.indexOf('-'));
-        } else {
-            normalizedJavaVersion = javaVersion;
+            return 8;
         }
-        return Integer.parseInt(normalizedJavaVersion);
+        if (javaVersion.startsWith("1.")) {
+            return Integer.parseInt(javaVersion.substring(2, 3));
+        }
+        int end = 0;
+        while (end < javaVersion.length() && Character.isDigit(javaVersion.charAt(end))) {
+            end++;
+        }
+        if (end == 0) {
+            return 8;
+        }
+        return Integer.parseInt(javaVersion.substring(0, end));
     }
 }

--- a/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
+++ b/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
@@ -16,7 +16,11 @@ public final class JavaVersionDetector {
             return Integer.parseInt(javaVersion.substring(2, 3));
         }
         int end = 0;
-        while (end < javaVersion.length() && Character.isDigit(javaVersion.charAt(end))) {
+        while (end < javaVersion.length()) {
+            char c = javaVersion.charAt(end);
+            if (c < '0' || c > '9') {
+                break;
+            }
             end++;
         }
         if (end == 0) {

--- a/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
@@ -83,4 +83,14 @@ public class JavaVersionDetectorTest {
         assertThat(JavaVersionDetector.getJavaMajorVersion("23-beta"), equalTo(23));
     }
 
+    @Test
+    public void javaVersionFor25beta() {
+        assertThat(JavaVersionDetector.getJavaMajorVersion("25-beta"), equalTo(25));
+    }
+
+    @Test
+    public void javaVersionFor25ea() {
+        assertThat(JavaVersionDetector.getJavaMajorVersion("25-ea"), equalTo(25));
+    }
+
 }

--- a/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
@@ -84,13 +84,19 @@ public class JavaVersionDetectorTest {
     }
 
     @Test
-    public void javaVersionFor25beta() {
-        assertThat(JavaVersionDetector.getJavaMajorVersion("25-beta"), equalTo(25));
+    public void javaVersionFor25WithPlusBuild() {
+        /*
+        Some EA / early builds report java.version with a +build suffix (e.g. 25+36).
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("25+36"), equalTo(25));
     }
 
     @Test
-    public void javaVersionFor25ea() {
-        assertThat(JavaVersionDetector.getJavaMajorVersion("25-ea"), equalTo(25));
+    public void javaVersionFor25WithPlusBuildAndEa() {
+        /*
+        OpenJDK EA can combine +build with an -ea suffix (e.g. 25+36-ea).
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("25+36-ea"), equalTo(25));
     }
 
 }


### PR DESCRIPTION
## Summary

- Parse the leading digit run from `java.version` instead of splitting on `.` or `-`, so early-access strings like `25-beta` and `25-ea` return the major version without `NumberFormatException`.
- Add unit tests for JDK 25 EA version strings reported in #296.

Fixes #296

## Test plan

- [x] `mvn -pl awaitility test -Dtest=JavaVersionDetectorTest` (JDK 17, 11/11 tests pass)


Made with [Cursor](https://cursor.com)